### PR TITLE
Fix Turso schema drift and harden production DB handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,65 @@ turso db shell authlab < migration.sql
 git add . && git commit -m "update schema" && git push
 ```
 
+Important notes:
+
+- `--from-config-datasource` reads from the datasource in `prisma.config.ts` (local SQLite in this project). If local SQLite is ahead of Turso, the generated diff can be empty even when Turso is missing tables/columns.
+- Always verify production schema directly in Turso before closing a deployment.
+
+Production verification checklist:
+
+1. Confirm key tables exist:
+   ```bash
+   turso db shell authlab ".tables"
+   ```
+2. Confirm expected columns for changed tables:
+   ```bash
+   turso db shell authlab ".schema SystemSetting"
+   ```
+3. Re-test affected flows against production (for example: user registration, admin settings).
+
+### Production Schema Drift Recovery
+
+If production is missing `SystemSetting`, apply this emergency SQL:
+
+```sql
+CREATE TABLE IF NOT EXISTS "SystemSetting" (
+  "key" TEXT NOT NULL PRIMARY KEY,
+  "value" TEXT NOT NULL,
+  "updatedAt" DATETIME NOT NULL
+);
+```
+
+Then verify:
+
+```bash
+turso db shell authlab ".schema SystemSetting"
+```
+
+### Legacy AppInstance Schema Reconciliation
+
+If production still has legacy `AppInstance` without `teamId`, run:
+
+```bash
+turso db shell authlab < prisma/production-reconcile-2026-03-05.sql
+```
+
+What this does:
+
+- Creates `SystemSetting` if missing.
+- Creates a legacy team (`legacy_migration_team`) if missing.
+- Rebuilds `AppInstance` with required `teamId` + foreign key to `Team`.
+- Preserves existing `AppInstance` rows by assigning them to the legacy team.
+- On first user registration, AuthLab automatically reassigns legacy-team apps to that first user's personal team.
+
+Post-checks:
+
+```bash
+turso db shell authlab ".schema AppInstance"
+turso db shell authlab "PRAGMA table_info(\"AppInstance\");"
+turso db shell authlab "PRAGMA foreign_key_list(\"AppInstance\");"
+```
+
 ## Project Structure
 
 ```

--- a/prisma/production-reconcile-2026-03-05.sql
+++ b/prisma/production-reconcile-2026-03-05.sql
@@ -1,0 +1,96 @@
+-- Production schema reconciliation for legacy deployments.
+-- Date: 2026-03-05
+--
+-- Purpose:
+-- 1) Ensure SystemSetting exists (registration/admin settings safety).
+-- 2) Rebuild legacy AppInstance to include required teamId + foreign key.
+-- 3) Preserve existing AppInstance rows by assigning them to a legacy team.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS "SystemSetting" (
+  "key" TEXT NOT NULL PRIMARY KEY,
+  "value" TEXT NOT NULL,
+  "updatedAt" DATETIME NOT NULL
+);
+
+INSERT OR IGNORE INTO "Team" (
+  "id",
+  "name",
+  "slug",
+  "isPersonal",
+  "createdAt",
+  "updatedAt"
+)
+VALUES (
+  'legacy_migration_team',
+  'Legacy Imported Apps',
+  'legacy-imported-apps',
+  false,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+);
+
+CREATE TABLE "AppInstance_new" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "name" TEXT NOT NULL,
+  "slug" TEXT NOT NULL,
+  "protocol" TEXT NOT NULL,
+  "teamId" TEXT NOT NULL,
+  "issuerUrl" TEXT,
+  "clientId" TEXT,
+  "clientSecret" TEXT,
+  "scopes" TEXT DEFAULT 'openid profile email',
+  "entryPoint" TEXT,
+  "issuer" TEXT,
+  "idpCert" TEXT,
+  "buttonColor" TEXT DEFAULT '#3B71CA',
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" DATETIME NOT NULL,
+  CONSTRAINT "AppInstance_teamId_fkey"
+    FOREIGN KEY ("teamId")
+    REFERENCES "Team" ("id")
+    ON DELETE CASCADE
+    ON UPDATE CASCADE
+);
+
+INSERT INTO "AppInstance_new" (
+  "id",
+  "name",
+  "slug",
+  "protocol",
+  "teamId",
+  "issuerUrl",
+  "clientId",
+  "clientSecret",
+  "scopes",
+  "entryPoint",
+  "issuer",
+  "idpCert",
+  "buttonColor",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  "id",
+  "name",
+  "slug",
+  "protocol",
+  'legacy_migration_team',
+  "issuerUrl",
+  "clientId",
+  "clientSecret",
+  "scopes",
+  "entryPoint",
+  "issuer",
+  "idpCert",
+  "buttonColor",
+  "createdAt",
+  "updatedAt"
+FROM "AppInstance";
+
+DROP TABLE "AppInstance";
+ALTER TABLE "AppInstance_new" RENAME TO "AppInstance";
+CREATE UNIQUE INDEX "AppInstance_slug_key" ON "AppInstance"("slug");
+
+COMMIT;

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -1,9 +1,21 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/user-session";
+import { UpdateSystemSettingSchema } from "@/lib/validators";
 import {
   getAllSettings,
   setSetting,
+  SystemSettingSchemaOutOfSyncError,
 } from "@/repositories/system-setting.repo";
+
+function schemaOutOfSyncResponse() {
+  return NextResponse.json(
+    {
+      error: "System settings schema is out of sync with this deployment.",
+      hint: 'Create the "SystemSetting" table in Turso and apply the latest schema migration.',
+    },
+    { status: 503 },
+  );
+}
 
 export async function GET() {
   const user = await getCurrentUser();
@@ -11,8 +23,20 @@ export async function GET() {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const settings = await getAllSettings();
-  return NextResponse.json(settings);
+  try {
+    const settings = await getAllSettings();
+    return NextResponse.json(settings);
+  } catch (error) {
+    if (error instanceof SystemSettingSchemaOutOfSyncError) {
+      return schemaOutOfSyncResponse();
+    }
+
+    console.error("Failed to load system settings", error);
+    return NextResponse.json(
+      { error: "Failed to load system settings" },
+      { status: 500 },
+    );
+  }
 }
 
 export async function PUT(request: Request) {
@@ -22,15 +46,26 @@ export async function PUT(request: Request) {
   }
 
   const body = await request.json();
-  const { key, value } = body;
-
-  if (!key || typeof key !== "string" || typeof value !== "string") {
+  const parsed = UpdateSystemSettingSchema.safeParse(body);
+  if (!parsed.success) {
     return NextResponse.json(
-      { error: "key and value are required strings" },
+      { error: "Validation failed", issues: parsed.error.issues },
       { status: 400 },
     );
   }
 
-  await setSetting(key, value);
-  return NextResponse.json({ ok: true });
+  try {
+    await setSetting(parsed.data.key, parsed.data.value);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    if (error instanceof SystemSettingSchemaOutOfSyncError) {
+      return schemaOutOfSyncResponse();
+    }
+
+    console.error("Failed to update system settings", error);
+    return NextResponse.json(
+      { error: "Failed to update system settings" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/user/register/route.ts
+++ b/src/app/api/user/register/route.ts
@@ -5,6 +5,7 @@ import { getUserSession } from "@/lib/user-session";
 import { createUser, getUserByEmail, countUsers } from "@/repositories/user.repo";
 import { createTeam } from "@/repositories/team.repo";
 import { addTeamMember } from "@/repositories/team.repo";
+import { claimLegacyMigrationAppsForTeam } from "@/repositories/app-instance.repo";
 import { getSetting } from "@/repositories/system-setting.repo";
 
 export async function POST(request: Request) {
@@ -58,6 +59,10 @@ export async function POST(request: Request) {
   });
 
   await addTeamMember(personalTeam.id, user.id, "OWNER");
+
+  if (isSystemAdmin) {
+    await claimLegacyMigrationAppsForTeam(personalTeam.id);
+  }
 
   // Set user session
   const session = await getUserSession();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -7,22 +7,44 @@ const globalForPrisma = globalThis as unknown as {
 let prismaPromise: Promise<PrismaClient> | null = null;
 
 async function createPrismaClient(): Promise<PrismaClient> {
-  if (process.env.TURSO_DATABASE_URL && process.env.TURSO_AUTH_TOKEN) {
+  const tursoUrl = process.env.TURSO_DATABASE_URL?.trim();
+  const tursoAuthToken = process.env.TURSO_AUTH_TOKEN?.trim();
+  const hasTursoUrl = Boolean(tursoUrl);
+  const hasTursoAuthToken = Boolean(tursoAuthToken);
+
+  if (hasTursoUrl !== hasTursoAuthToken) {
+    throw new Error(
+      "Database misconfiguration: TURSO_DATABASE_URL and TURSO_AUTH_TOKEN must either both be set or both be unset.",
+    );
+  }
+
+  if (hasTursoUrl && hasTursoAuthToken) {
     const { PrismaLibSql } = await import("@prisma/adapter-libsql");
     const adapter = new PrismaLibSql({
-      url: process.env.TURSO_DATABASE_URL,
-      authToken: process.env.TURSO_AUTH_TOKEN,
-    });
-    return new PrismaClient({ adapter });
-  } else {
-    const { PrismaBetterSqlite3 } = await import(
-      "@prisma/adapter-better-sqlite3"
-    );
-    const adapter = new PrismaBetterSqlite3({
-      url: process.env.DATABASE_URL!,
+      url: tursoUrl!,
+      authToken: tursoAuthToken!,
     });
     return new PrismaClient({ adapter });
   }
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "Database misconfiguration: TURSO_DATABASE_URL and TURSO_AUTH_TOKEN are required in production.",
+    );
+  }
+
+  const sqliteUrl = process.env.DATABASE_URL?.trim();
+  if (!sqliteUrl) {
+    throw new Error(
+      "Database misconfiguration: DATABASE_URL is required for non-production environments.",
+    );
+  }
+
+  const { PrismaBetterSqlite3 } = await import("@prisma/adapter-better-sqlite3");
+  const adapter = new PrismaBetterSqlite3({
+    url: sqliteUrl,
+  });
+  return new PrismaClient({ adapter });
 }
 
 export async function getPrisma(): Promise<PrismaClient> {

--- a/src/repositories/app-instance.repo.ts
+++ b/src/repositories/app-instance.repo.ts
@@ -7,6 +7,8 @@ import type {
 } from "@/types/app-instance";
 import type { PrismaClient } from "@/generated/prisma/client/client";
 
+const LEGACY_MIGRATION_TEAM_ID = "legacy_migration_team";
+
 type AppInstanceRecord = NonNullable<
   Awaited<ReturnType<PrismaClient["appInstance"]["findUnique"]>>
 >;
@@ -117,4 +119,15 @@ export async function getRedactedAppInstanceById(
   const record = await prisma.appInstance.findUnique({ where: { id } });
   if (!record) return null;
   return redactRecord(record);
+}
+
+export async function claimLegacyMigrationAppsForTeam(
+  teamId: string,
+): Promise<number> {
+  const prisma = await getPrisma();
+  const result = await prisma.appInstance.updateMany({
+    where: { teamId: LEGACY_MIGRATION_TEAM_ID },
+    data: { teamId },
+  });
+  return result.count;
 }

--- a/src/repositories/system-setting.repo.ts
+++ b/src/repositories/system-setting.repo.ts
@@ -1,22 +1,99 @@
 import { getPrisma } from "@/lib/db";
 
+export class SystemSettingSchemaOutOfSyncError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SystemSettingSchemaOutOfSyncError";
+  }
+}
+
+function matchesMissingSystemSettingTableError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  if (code === "P2021") {
+    const meta = (error as { meta?: unknown }).meta;
+    if (meta && typeof meta === "object") {
+      const table = (meta as { table?: unknown }).table;
+      const modelName = (meta as { modelName?: unknown }).modelName;
+      if (
+        (typeof table === "string" && /SystemSetting/i.test(table)) ||
+        (typeof modelName === "string" && /SystemSetting/i.test(modelName))
+      ) {
+        return true;
+      }
+    }
+
+    // Treat unknown P2021 metadata as schema drift for this repository.
+    return true;
+  }
+
+  return (
+    /no such table/i.test(error.message) && /SystemSetting/i.test(error.message)
+  );
+}
+
+function isMissingSystemSettingTableError(error: unknown): boolean {
+  let current: unknown = error;
+
+  while (current) {
+    if (matchesMissingSystemSettingTableError(current)) {
+      return true;
+    }
+
+    if (!(current instanceof Error) || !("cause" in current)) {
+      return false;
+    }
+
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  return false;
+}
+
 export async function getSetting(key: string): Promise<string | null> {
   const prisma = await getPrisma();
-  const setting = await prisma.systemSetting.findUnique({ where: { key } });
-  return setting?.value ?? null;
+  try {
+    const setting = await prisma.systemSetting.findUnique({ where: { key } });
+    return setting?.value ?? null;
+  } catch (error) {
+    if (isMissingSystemSettingTableError(error)) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 export async function setSetting(key: string, value: string): Promise<void> {
   const prisma = await getPrisma();
-  await prisma.systemSetting.upsert({
-    where: { key },
-    update: { value },
-    create: { key, value },
-  });
+  try {
+    await prisma.systemSetting.upsert({
+      where: { key },
+      update: { value },
+      create: { key, value },
+    });
+  } catch (error) {
+    if (isMissingSystemSettingTableError(error)) {
+      throw new SystemSettingSchemaOutOfSyncError(
+        "System settings table is missing in the database. Apply the latest schema migration to production.",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 }
 
 export async function getAllSettings(): Promise<Record<string, string>> {
   const prisma = await getPrisma();
-  const settings = await prisma.systemSetting.findMany();
-  return Object.fromEntries(settings.map((s) => [s.key, s.value]));
+  try {
+    const settings = await prisma.systemSetting.findMany();
+    return Object.fromEntries(settings.map((s) => [s.key, s.value]));
+  } catch (error) {
+    if (isMissingSystemSettingTableError(error)) {
+      return {};
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary
- enforce strict production Turso configuration in Prisma client initialization
- add schema-drift-safe handling for SystemSetting reads/writes
- validate admin settings payloads with Zod and return actionable 503 errors for schema mismatch
- add legacy AppInstance reconciliation SQL runbook and docs
- auto-claim legacy migrated apps for the first registered user

## Production reconciliation performed
- created missing auth/settings tables in Turso
- rebuilt AppInstance with required teamId + Team foreign key
- preserved existing AppInstance rows and assigned to legacy_migration_team
- verified tables, indexes, and foreign keys

## Validation
- npm run lint (pass)
- production /api/user/register smoke request with invalid payload returns validation 400 (no schema crash)