### PR TITLE
Dashboard-first team management and cross-team app transfer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,12 @@
 **Focus Areas**:
 - UI primitives in `src/components/ui/` — Button, Card, Input, Modal, Tabs, Stepper, Badge, CopyButton
 - Layout in `src/components/layout/AppShell.tsx` — sidebar navigation, responsive design
-- App management in `src/components/apps/` — Dashboard grid, CreationStepper (4-step flow), EditForm
+- App management in `src/components/apps/` — Dashboard grid, TeamMembersPanel, CreationStepper (4-step flow), EditForm
 - Inspector in `src/components/inspector/` — ClaimsTable, RawPayloadView, JWTDecoder, SessionInfo
+- Dashboard-first team UX:
+  - `src/app/(dashboard)/page.tsx` renders apps + active-team member panel
+  - `src/components/apps/TeamMembersPanel.tsx` handles member listing, add/invite, remove actions
+  - `src/components/apps/AppInstanceCard.tsx` provides move/copy transfer actions between teams
 
 **Design System**:
 - Primary color: `#3B71CA` (TW-Elements blue) — defined as `--color-primary` in `globals.css`
@@ -68,10 +72,12 @@
 **Focus Areas**:
 - Prisma schema in `prisma/schema.prisma` — AppInstance model, Protocol enum
 - Prisma config in `prisma.config.ts` — datasource URL (always local SQLite for CLI)
-- Database client in `src/lib/db.ts` — async `getPrisma()` with dual adapter pattern
-- Repository layer in `src/repositories/app-instance.repo.ts` — CRUD with encryption, uses `await getPrisma()`
+- Database client in `src/lib/db.ts` — async `getPrisma()` with strict production Turso checks
+- Repository layer in `src/repositories/app-instance.repo.ts` — CRUD + move/copy transfer helpers with encryption
+- Team repositories in `src/repositories/team.repo.ts` — memberships, role checks, owner-count checks for leave flow
 - API routes in `src/app/api/apps/` — REST endpoints with Zod validation
-- Validation schemas in `src/lib/validators.ts` — discriminated unions for OIDC/SAML
+- Team API routes in `src/app/api/teams/` — member management and leave flows
+- Validation schemas in `src/lib/validators.ts` — OIDC/SAML + transfer/member-management schemas
 
 **Database Notes**:
 - **Local**: Prisma 7 + `@prisma/adapter-better-sqlite3` driver adapter, SQLite file at `./dev.db`
@@ -82,6 +88,7 @@
 - Prisma CLI does NOT support `libsql://` URLs — use `prisma migrate diff` + `turso db shell` for production schema changes
 - `clientSecret` and `idpCert` are AES-256-GCM encrypted; encryption/decryption happens only in the repository layer
 - `next.config.ts` externalizes `better-sqlite3` via `serverExternalPackages` (native module, incompatible with Vercel bundling)
+- App copy flow re-encrypts secrets by going through repository create paths (fresh IV/auth tag)
 
 ## Development Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,10 @@ turso db shell authlab < migration.sql
 src/
 ├── app/                      # Next.js App Router pages and routes
 │   ├── api/apps/             # CRUD REST API for app instances
+│   │   └── [id]/transfer/    # Cross-team app move/copy endpoint
 │   ├── api/auth/callback/    # Global OIDC + SAML callback handlers
 │   ├── api/auth/logout/      # Session destruction
+│   ├── api/teams/[id]/       # Team detail, delete, leave, members, invites
 │   ├── apps/new/             # Creation stepper UI
 │   ├── apps/[id]/            # Edit app instance UI
 │   ├── test/[slug]/          # Test landing page + login route + inspector
@@ -66,11 +68,13 @@ src/
 │   ├── validators.ts         # Zod schemas for API input validation
 │   └── db.ts                 # Async getPrisma() — dual adapter (libSQL for Turso, better-sqlite3 for local)
 ├── repositories/             # Data access layer
-│   └── app-instance.repo.ts  # CRUD with transparent encrypt/decrypt on secrets
+│   ├── app-instance.repo.ts  # CRUD + move/copy transfer helpers (secrets re-encrypted on copy)
+│   ├── team.repo.ts          # Team membership/role/owner-count helpers
+│   └── invite.repo.ts        # Invite token lifecycle
 ├── components/               # React components
 │   ├── ui/                   # Primitives: Button, Card, Input, Modal, Tabs, Stepper, Badge
 │   ├── layout/               # AppShell (sidebar + content)
-│   ├── apps/                 # Dashboard, CreationStepper, EditForm, ConfigFields
+│   ├── apps/                 # Dashboard, TeamMembersPanel, App card transfer UI, CreationStepper, EditForm
 │   └── inspector/            # ClaimsTable, RawPayloadView, JWTDecoder, SessionInfo
 └── types/                    # TypeScript interfaces
 ```
@@ -87,7 +91,24 @@ src/
 
 5. **Secret Redaction**: GET endpoints return `hasClientSecret: boolean` instead of actual secrets. Secrets are never exposed via the API.
 
-6. **Dual Database Adapter**: `db.ts` exports an async `getPrisma()` that dynamically imports the correct adapter — `@prisma/adapter-libsql` when `TURSO_DATABASE_URL` is set (production/Vercel), `@prisma/adapter-better-sqlite3` otherwise (local dev).
+6. **Dual Database Adapter with Production Guardrails**: `db.ts` exports async `getPrisma()` and enforces strict production configuration:
+   - both `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` must be set in production
+   - partial Turso env config throws startup/runtime errors instead of silently falling back
+
+7. **Dashboard-First Team Management**:
+   - Team switcher controls active team
+   - Dashboard shows active-team apps plus a right-side members panel
+   - Member add/invite/remove actions are performed from dashboard context
+
+8. **Cross-Team App Transfer**:
+   - `POST /api/apps/[id]/transfer` supports `MOVE` and `COPY`
+   - Caller must be `OWNER`/`ADMIN` on both source and target teams
+   - Copy flow duplicates config and re-encrypts secrets through repository create path
+
+9. **Membership Leave Flow**:
+   - `POST /api/teams/[id]/leave` removes current user from non-personal team
+   - Last-owner leave is blocked
+   - If leaving active team, session falls back to personal team or first available team
 
 ### Prisma 7 Notes
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A developer tool for dynamically creating, saving, and launching isolated OIDC o
 - **Global Callback Routing** — One callback URL per protocol; state/RelayState maps back to the correct tenant
 - **Encryption at Rest** — Client secrets and IdP certificates encrypted with AES-256-GCM in the database
 - **Secret Redaction** — API never exposes actual secrets; returns `hasClientSecret: boolean` instead
+- **Team-Centric Dashboard** — Team switcher updates apps and shows live team membership/actions in the dashboard sidebar
+- **Cross-Team App Transfer** — Team admins/owners can move or copy app configurations across teams
 
 ## Tech Stack
 

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link";
 import { requireUser } from "@/lib/user-session";
 import { listAppInstancesByTeam } from "@/repositories/app-instance.repo";
+import {
+  getTeamById,
+  getTeamMembership,
+  listTeamMembers,
+} from "@/repositories/team.repo";
 import { Button } from "@/components/ui/Button";
 import { Dashboard } from "@/components/apps/Dashboard";
 
@@ -8,39 +13,39 @@ export const dynamic = "force-dynamic";
 
 export default async function HomePage() {
   const user = await requireUser();
-  const apps = await listAppInstancesByTeam(user.activeTeamId);
-
-  if (apps.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] text-center">
-        <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
-          <svg className="w-8 h-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-          </svg>
-        </div>
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">
-          Welcome to AuthLab
-        </h1>
-        <p className="text-gray-500 mb-6 max-w-md">
-          Create your first OIDC or SAML test instance to start testing
-          authentication flows.
-        </p>
-        <Link href="/apps/new">
-          <Button size="lg">Create Your First App</Button>
-        </Link>
-      </div>
-    );
-  }
+  const [apps, team, membership] = await Promise.all([
+    listAppInstancesByTeam(user.activeTeamId),
+    getTeamById(user.activeTeamId),
+    getTeamMembership(user.userId, user.activeTeamId),
+  ]);
+  const members = team ? await listTeamMembers(team.id) : [];
 
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+          {team && (
+            <p className="text-sm text-gray-500 mt-1">
+              Active team: {team.isPersonal ? "Personal Workspace" : team.name}
+            </p>
+          )}
+        </div>
         <Link href="/apps/new">
           <Button>Create New App</Button>
         </Link>
       </div>
-      <Dashboard initialApps={apps} />
+      <Dashboard
+        initialApps={apps}
+        team={{
+          id: user.activeTeamId,
+          name: team?.name || "Unknown Team",
+          isPersonal: team?.isPersonal ?? false,
+          currentRole: membership?.role || "MEMBER",
+          members,
+        }}
+        currentUserId={user.userId}
+      />
     </div>
   );
 }

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -3,10 +3,10 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useUser } from "@/components/providers/UserProvider";
+import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Card } from "@/components/ui/Card";
-import Link from "next/link";
 
 export default function SettingsPage() {
   const user = useUser();
@@ -20,6 +20,7 @@ export default function SettingsPage() {
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
   const [loading, setLoading] = useState(false);
+  const [leavingTeamId, setLeavingTeamId] = useState<string | null>(null);
 
   async function handleProfile(e: React.FormEvent) {
     e.preventDefault();
@@ -91,6 +92,30 @@ export default function SettingsPage() {
       setError("An unexpected error occurred");
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function handleLeaveTeam(teamId: string) {
+    setError("");
+    setSuccess("");
+    setLeavingTeamId(teamId);
+
+    try {
+      const res = await fetch(`/api/teams/${teamId}/leave`, {
+        method: "POST",
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Failed to leave team");
+        return;
+      }
+
+      setSuccess("You have left the team");
+      router.refresh();
+    } catch {
+      setError("An unexpected error occurred");
+    } finally {
+      setLeavingTeamId(null);
     }
   }
 
@@ -173,7 +198,9 @@ export default function SettingsPage() {
 
       {/* Teams */}
       <Card>
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Your Teams</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          Team Memberships
+        </h2>
         <div className="divide-y divide-gray-100">
           {user.teams.map((team) => (
             <div
@@ -185,21 +212,43 @@ export default function SettingsPage() {
                   {team.isPersonal ? "Personal Workspace" : team.name}
                 </div>
                 <div className="text-sm text-gray-500">
-                  {team.memberCount} member{team.memberCount !== 1 ? "s" : ""} ·{" "}
+                  <span className="mr-2">{team.role}</span>· {team.memberCount} member
+                  {team.memberCount !== 1 ? "s" : ""} ·{" "}
                   {team.appCount} app{team.appCount !== 1 ? "s" : ""}
                 </div>
               </div>
-              {!team.isPersonal && (
-                <Link
-                  href={`/teams/${team.id}`}
-                  className="text-sm text-primary hover:underline"
-                >
-                  Manage
-                </Link>
-              )}
+              <div className="flex items-center gap-2">
+                {team.id === user.activeTeamId && (
+                  <Badge variant="blue">Active</Badge>
+                )}
+                {!team.isPersonal && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleLeaveTeam(team.id)}
+                    loading={leavingTeamId === team.id}
+                    className="text-red-600 hover:text-red-700"
+                  >
+                    Leave
+                  </Button>
+                )}
+                {team.isPersonal && (
+                  <Badge variant="gray">Required</Badge>
+                )}
+              </div>
             </div>
           ))}
         </div>
+      </Card>
+
+      <Card>
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">
+          Team Management
+        </h2>
+        <p className="text-sm text-gray-500">
+          Team member management and invites are available directly on the dashboard
+          for the currently active team.
+        </p>
       </Card>
     </div>
   );

--- a/src/app/(dashboard)/teams/[id]/page.tsx
+++ b/src/app/(dashboard)/teams/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
+import { useUser } from "@/components/providers/UserProvider";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Card } from "@/components/ui/Card";
@@ -31,6 +32,7 @@ interface TeamData {
 }
 
 export default function TeamDetailPage() {
+  const user = useUser();
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [team, setTeam] = useState<TeamData | null>(null);
@@ -47,6 +49,11 @@ export default function TeamDetailPage() {
   const [showDelete, setShowDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
+  const currentTeam = user.teams.find((team) => team.id === id);
+  const canManage = currentTeam
+    ? currentTeam.role === "OWNER" || currentTeam.role === "ADMIN"
+    : false;
+
   async function fetchTeam() {
     const res = await fetch(`/api/teams/${id}`);
     if (res.ok) {
@@ -62,9 +69,13 @@ export default function TeamDetailPage() {
   }
 
   useEffect(() => {
-    Promise.all([fetchTeam(), fetchInvites()]).finally(() => setLoading(false));
+    const requests = [fetchTeam()];
+    if (canManage) {
+      requests.push(fetchInvites());
+    }
+    Promise.all(requests).finally(() => setLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
+  }, [id, canManage]);
 
   async function handleInvite(e: React.FormEvent) {
     e.preventDefault();
@@ -144,7 +155,7 @@ export default function TeamDetailPage() {
     <div className="max-w-2xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">{team.name}</h1>
-        {!team.isPersonal && (
+        {!team.isPersonal && canManage && (
           <Button variant="danger" size="sm" onClick={() => setShowDelete(true)}>
             Delete Team
           </Button>
@@ -177,22 +188,30 @@ export default function TeamDetailPage() {
                   <Badge variant="blue">Owner</Badge>
                 ) : (
                   <>
-                    <select
-                      value={member.role}
-                      onChange={(e) =>
-                        handleRoleChange(member.user.id, e.target.value)
-                      }
-                      className="text-sm border border-gray-200 rounded px-2 py-1"
-                    >
-                      <option value="ADMIN">Admin</option>
-                      <option value="MEMBER">Member</option>
-                    </select>
-                    <button
-                      onClick={() => handleRemoveMember(member.user.id)}
-                      className="text-sm text-red-600 hover:text-red-800"
-                    >
-                      Remove
-                    </button>
+                    {canManage ? (
+                      <>
+                        <select
+                          value={member.role}
+                          onChange={(e) =>
+                            handleRoleChange(member.user.id, e.target.value)
+                          }
+                          className="text-sm border border-gray-200 rounded px-2 py-1"
+                        >
+                          <option value="ADMIN">Admin</option>
+                          <option value="MEMBER">Member</option>
+                        </select>
+                        <button
+                          onClick={() => handleRemoveMember(member.user.id)}
+                          className="text-sm text-red-600 hover:text-red-800"
+                        >
+                          Remove
+                        </button>
+                      </>
+                    ) : (
+                      <Badge variant={member.role === "ADMIN" ? "green" : "gray"}>
+                        {member.role}
+                      </Badge>
+                    )}
                   </>
                 )}
               </div>
@@ -202,7 +221,7 @@ export default function TeamDetailPage() {
       </Card>
 
       {/* Invite */}
-      {!team.isPersonal && (
+      {!team.isPersonal && canManage && (
         <Card>
           <h2 className="text-lg font-semibold text-gray-900 mb-4">
             Invite Members

--- a/src/app/api/apps/[id]/transfer/route.ts
+++ b/src/app/api/apps/[id]/transfer/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/user-session";
+import { TransferAppSchema } from "@/lib/validators";
+import {
+  copyAppInstanceToTeam,
+  getRedactedAppInstanceById,
+  moveAppInstanceToTeam,
+} from "@/repositories/app-instance.repo";
+import { getTeamById, getTeamMembership } from "@/repositories/team.repo";
+
+function canManageTeam(role: string | undefined): boolean {
+  return role === "OWNER" || role === "ADMIN";
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const parsed = TransferAppSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const app = await getRedactedAppInstanceById(id);
+  if (!app) {
+    return NextResponse.json({ error: "App not found" }, { status: 404 });
+  }
+
+  if (parsed.data.targetTeamId === app.teamId) {
+    return NextResponse.json(
+      { error: "Target team must be different from source team" },
+      { status: 400 },
+    );
+  }
+
+  const targetTeam = await getTeamById(parsed.data.targetTeamId);
+  if (!targetTeam) {
+    return NextResponse.json({ error: "Target team not found" }, { status: 404 });
+  }
+
+  const [sourceMembership, targetMembership] = await Promise.all([
+    getTeamMembership(user.userId, app.teamId),
+    getTeamMembership(user.userId, parsed.data.targetTeamId),
+  ]);
+
+  if (!canManageTeam(sourceMembership?.role)) {
+    return NextResponse.json(
+      { error: "Insufficient permissions on source team" },
+      { status: 403 },
+    );
+  }
+
+  if (!canManageTeam(targetMembership?.role)) {
+    return NextResponse.json(
+      { error: "Insufficient permissions on target team" },
+      { status: 403 },
+    );
+  }
+
+  const transferredApp =
+    parsed.data.mode === "MOVE"
+      ? await moveAppInstanceToTeam(id, parsed.data.targetTeamId)
+      : await copyAppInstanceToTeam(id, parsed.data.targetTeamId);
+
+  return NextResponse.json({
+    mode: parsed.data.mode,
+    app: transferredApp,
+  });
+}

--- a/src/app/api/teams/[id]/leave/route.ts
+++ b/src/app/api/teams/[id]/leave/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { AuthError, requireTeamAccess } from "@/lib/authorize";
+import { getUserSession } from "@/lib/user-session";
+import {
+  countOwners,
+  getTeamById,
+  getTeamsByUserId,
+  removeTeamMember,
+} from "@/repositories/team.repo";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  let accessor;
+  try {
+    accessor = await requireTeamAccess(id);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    throw error;
+  }
+
+  const team = await getTeamById(id);
+  if (!team) {
+    return NextResponse.json({ error: "Team not found" }, { status: 404 });
+  }
+  if (team.isPersonal) {
+    return NextResponse.json(
+      { error: "Cannot leave personal workspace" },
+      { status: 400 },
+    );
+  }
+
+  if (accessor.membership.role === "OWNER") {
+    const ownerCount = await countOwners(id);
+    if (ownerCount <= 1) {
+      return NextResponse.json(
+        { error: "You are the last owner. Add another owner before leaving." },
+        { status: 409 },
+      );
+    }
+  }
+
+  await removeTeamMember(id, accessor.user.userId);
+
+  let activeTeamId = accessor.user.activeTeamId;
+  if (accessor.user.activeTeamId === id) {
+    const remainingTeams = await getTeamsByUserId(accessor.user.userId);
+    const fallbackTeam =
+      remainingTeams.find((teamMember) => teamMember.isPersonal) ||
+      remainingTeams[0];
+
+    if (!fallbackTeam) {
+      return NextResponse.json(
+        { error: "No team available after leaving" },
+        { status: 500 },
+      );
+    }
+
+    const session = await getUserSession();
+    session.activeTeamId = fallbackTeam.id;
+    await session.save();
+    activeTeamId = fallbackTeam.id;
+  }
+
+  return NextResponse.json({ ok: true, activeTeamId });
+}

--- a/src/app/api/teams/[id]/members/route.ts
+++ b/src/app/api/teams/[id]/members/route.ts
@@ -1,0 +1,74 @@
+import crypto from "crypto";
+import { NextResponse } from "next/server";
+import { AuthError, requireTeamAccess } from "@/lib/authorize";
+import { AddOrInviteMemberSchema } from "@/lib/validators";
+import { getUserByEmail } from "@/repositories/user.repo";
+import { createInvite } from "@/repositories/invite.repo";
+import {
+  addTeamMember,
+  getTeamById,
+  getTeamMembership,
+} from "@/repositories/team.repo";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  let accessor;
+  try {
+    accessor = await requireTeamAccess(id, ["OWNER", "ADMIN"]);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    throw error;
+  }
+
+  const team = await getTeamById(id);
+  if (!team) {
+    return NextResponse.json({ error: "Team not found" }, { status: 404 });
+  }
+  if (team.isPersonal) {
+    return NextResponse.json(
+      { error: "Cannot modify members of personal workspace" },
+      { status: 400 },
+    );
+  }
+
+  const body = await request.json();
+  const parsed = AddOrInviteMemberSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const existingUser = await getUserByEmail(parsed.data.email);
+  if (existingUser) {
+    const membership = await getTeamMembership(existingUser.id, id);
+    if (membership) {
+      return NextResponse.json(
+        { error: "User is already a team member" },
+        { status: 409 },
+      );
+    }
+
+    const addedMember = await addTeamMember(id, existingUser.id, parsed.data.role);
+    return NextResponse.json({ mode: "added", member: addedMember });
+  }
+
+  const token = crypto.randomBytes(32).toString("hex");
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const invite = await createInvite({
+    token,
+    email: parsed.data.email,
+    role: parsed.data.role,
+    teamId: id,
+    invitedById: accessor.user.userId,
+    expiresAt,
+  });
+  return NextResponse.json({ mode: "invited", invite });
+}

--- a/src/app/api/teams/[id]/route.ts
+++ b/src/app/api/teams/[id]/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 import { AuthError, requireTeamAccess } from "@/lib/authorize";
+import { getUserSession } from "@/lib/user-session";
 import { UpdateTeamSchema } from "@/lib/validators";
 import {
   getTeamById,
   updateTeam,
   deleteTeam,
   listTeamMembers,
+  getTeamsByUserId,
 } from "@/repositories/team.repo";
 
 export async function GET(
@@ -78,8 +80,9 @@ export async function DELETE(
 ) {
   const { id } = await params;
 
+  let accessor;
   try {
-    await requireTeamAccess(id, ["OWNER"]);
+    accessor = await requireTeamAccess(id, ["OWNER", "ADMIN"]);
   } catch (e) {
     if (e instanceof AuthError) {
       return NextResponse.json({ error: e.message }, { status: e.status });
@@ -99,5 +102,19 @@ export async function DELETE(
   }
 
   await deleteTeam(id);
-  return NextResponse.json({ ok: true });
+
+  let activeTeamId = accessor.user.activeTeamId;
+  if (accessor.user.activeTeamId === id) {
+    const remainingTeams = await getTeamsByUserId(accessor.user.userId);
+    const fallbackTeam =
+      remainingTeams.find((member) => member.isPersonal) || remainingTeams[0];
+    if (fallbackTeam) {
+      const session = await getUserSession();
+      session.activeTeamId = fallbackTeam.id;
+      await session.save();
+      activeTeamId = fallbackTeam.id;
+    }
+  }
+
+  return NextResponse.json({ ok: true, activeTeamId });
 }

--- a/src/app/test/[slug]/inspector/page.tsx
+++ b/src/app/test/[slug]/inspector/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { getAppSession } from "@/lib/session";
 import { Tabs } from "@/components/ui/Tabs";
 import { ClaimsTable } from "@/components/inspector/ClaimsTable";
@@ -49,9 +50,12 @@ export default async function InspectorPage({
 
   return (
     <div className="max-w-4xl mx-auto">
-      <h1 className="text-2xl font-bold text-gray-900 mb-4">
-        Auth Inspector
-      </h1>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold text-gray-900">Auth Inspector</h1>
+        <Link href="/" className="text-sm text-primary hover:underline">
+          Back to Dashboard
+        </Link>
+      </div>
 
       <SessionInfo
         slug={slug}

--- a/src/app/test/[slug]/page.tsx
+++ b/src/app/test/[slug]/page.tsx
@@ -47,6 +47,13 @@ export default async function TestPage({
           </button>
         </Link>
 
+        <Link
+          href="/"
+          className="mt-3 inline-block text-sm text-primary hover:underline"
+        >
+          Back to Dashboard
+        </Link>
+
         <div className="mt-6 pt-4 border-t border-gray-100">
           <p className="text-xs text-gray-400 mb-1">Callback URL</p>
           <code className="text-xs text-gray-600 bg-gray-50 px-2 py-1 rounded break-all">

--- a/src/components/apps/AppInstanceCard.tsx
+++ b/src/components/apps/AppInstanceCard.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import { useUser } from "@/components/providers/UserProvider";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
@@ -11,11 +12,27 @@ import type { RedactedAppInstance } from "@/types/app-instance";
 interface AppInstanceCardProps {
   app: RedactedAppInstance;
   onDelete: (id: string) => void;
+  onTransfer: (mode: "MOVE" | "COPY", app: RedactedAppInstance) => void;
 }
 
-export function AppInstanceCard({ app, onDelete }: AppInstanceCardProps) {
+export function AppInstanceCard({ app, onDelete, onTransfer }: AppInstanceCardProps) {
+  const { teams } = useUser();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [showTransferModal, setShowTransferModal] = useState(false);
+  const [targetTeamId, setTargetTeamId] = useState("");
+  const [transferError, setTransferError] = useState("");
+  const [transferringMode, setTransferringMode] = useState<"MOVE" | "COPY" | null>(
+    null,
+  );
+
+  const sourceMembership = teams.find((team) => team.id === app.teamId);
+  const canManageSourceTeam =
+    sourceMembership?.role === "OWNER" || sourceMembership?.role === "ADMIN";
+  const eligibleTargetTeams = teams.filter(
+    (team) =>
+      team.id !== app.teamId && (team.role === "OWNER" || team.role === "ADMIN"),
+  );
 
   const handleDelete = async () => {
     setDeleting(true);
@@ -27,6 +44,39 @@ export function AppInstanceCard({ app, onDelete }: AppInstanceCardProps) {
     } finally {
       setDeleting(false);
       setShowDeleteModal(false);
+    }
+  };
+
+  const openTransferModal = () => {
+    setTransferError("");
+    setTargetTeamId(eligibleTargetTeams[0]?.id || "");
+    setShowTransferModal(true);
+  };
+
+  const handleTransfer = async (mode: "MOVE" | "COPY") => {
+    if (!targetTeamId) {
+      setTransferError("Please select a target team");
+      return;
+    }
+
+    setTransferError("");
+    setTransferringMode(mode);
+    try {
+      const res = await fetch(`/api/apps/${app.id}/transfer`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode, targetTeamId }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setTransferError(data.error || "Failed to transfer app");
+        return;
+      }
+
+      onTransfer(mode, data.app);
+      setShowTransferModal(false);
+    } finally {
+      setTransferringMode(null);
     }
   };
 
@@ -63,6 +113,23 @@ export function AppInstanceCard({ app, onDelete }: AppInstanceCardProps) {
               Edit
             </Button>
           </Link>
+          {canManageSourceTeam && eligibleTargetTeams.length > 0 && (
+            <Button variant="ghost" size="sm" onClick={openTransferModal}>
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M7 16V4m0 0L3 8m4-4l4 4m6-4v12m0 0l-4-4m4 4l4-4"
+                />
+              </svg>
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="sm"
@@ -74,6 +141,55 @@ export function AppInstanceCard({ app, onDelete }: AppInstanceCardProps) {
           </Button>
         </div>
       </Card>
+
+      <Modal
+        isOpen={showTransferModal}
+        onClose={() => setShowTransferModal(false)}
+        title="Move or Copy App"
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            Choose a destination team where you are an admin/owner.
+          </p>
+          <select
+            value={targetTeamId}
+            onChange={(e) => setTargetTeamId(e.target.value)}
+            className="w-full h-10 rounded-lg border border-gray-200 px-3 text-sm"
+          >
+            {eligibleTargetTeams.map((team) => (
+              <option key={team.id} value={team.id}>
+                {team.isPersonal ? "Personal Workspace" : team.name}
+              </option>
+            ))}
+          </select>
+
+          {transferError && (
+            <p className="text-sm text-red-600">{transferError}</p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => setShowTransferModal(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="secondary"
+              loading={transferringMode === "COPY"}
+              onClick={() => handleTransfer("COPY")}
+            >
+              Copy
+            </Button>
+            <Button
+              loading={transferringMode === "MOVE"}
+              onClick={() => handleTransfer("MOVE")}
+            >
+              Move
+            </Button>
+          </div>
+        </div>
+      </Modal>
 
       <Modal
         isOpen={showDeleteModal}

--- a/src/components/apps/Dashboard.tsx
+++ b/src/components/apps/Dashboard.tsx
@@ -1,25 +1,85 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { AppInstanceCard } from "./AppInstanceCard";
+import { TeamMembersPanel } from "./TeamMembersPanel";
+import { Button } from "@/components/ui/Button";
 import type { RedactedAppInstance } from "@/types/app-instance";
 
 interface DashboardProps {
   initialApps: RedactedAppInstance[];
+  team: {
+    id: string;
+    name: string;
+    isPersonal: boolean;
+    currentRole: "OWNER" | "ADMIN" | "MEMBER";
+    members: Array<{
+      id: string;
+      role: "OWNER" | "ADMIN" | "MEMBER";
+      user: {
+        id: string;
+        name: string;
+        email: string;
+      };
+    }>;
+  };
+  currentUserId: string;
 }
 
-export function Dashboard({ initialApps }: DashboardProps) {
+export function Dashboard({ initialApps, team, currentUserId }: DashboardProps) {
   const [apps, setApps] = useState(initialApps);
 
   const handleDelete = (id: string) => {
     setApps((prev) => prev.filter((a) => a.id !== id));
   };
 
+  const handleTransfer = (
+    mode: "MOVE" | "COPY",
+    app: RedactedAppInstance,
+  ) => {
+    if (mode === "MOVE") {
+      setApps((prev) => prev.filter((existing) => existing.id !== app.id));
+      return;
+    }
+
+    if (app.teamId === team.id) {
+      setApps((prev) => [app, ...prev]);
+    }
+  };
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {apps.map((app) => (
-        <AppInstanceCard key={app.id} app={app} onDelete={handleDelete} />
-      ))}
+    <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_360px] gap-6 items-start">
+      {apps.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {apps.map((app) => (
+            <AppInstanceCard
+              key={app.id}
+              app={app}
+              onDelete={handleDelete}
+              onTransfer={handleTransfer}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-white p-8 text-center">
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">No Apps Yet</h2>
+          <p className="text-sm text-gray-500 mb-5">
+            This team does not have any app instances yet.
+          </p>
+          <Link href="/apps/new">
+            <Button>Create New App</Button>
+          </Link>
+        </div>
+      )}
+      <TeamMembersPanel
+        teamId={team.id}
+        teamName={team.name}
+        isPersonal={team.isPersonal}
+        currentUserId={currentUserId}
+        currentUserRole={team.currentRole}
+        initialMembers={team.members}
+      />
     </div>
   );
 }

--- a/src/components/apps/TeamMembersPanel.tsx
+++ b/src/components/apps/TeamMembersPanel.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+
+type TeamRole = "OWNER" | "ADMIN" | "MEMBER";
+
+interface TeamMember {
+  id: string;
+  role: TeamRole;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+  };
+}
+
+interface TeamMembersPanelProps {
+  teamId: string;
+  teamName: string;
+  isPersonal: boolean;
+  currentUserId: string;
+  currentUserRole: TeamRole;
+  initialMembers: TeamMember[];
+}
+
+function canManage(role: TeamRole): boolean {
+  return role === "OWNER" || role === "ADMIN";
+}
+
+function canRemoveMember(
+  currentUserRole: TeamRole,
+  targetRole: TeamRole,
+): boolean {
+  if (targetRole === "OWNER") {
+    return false;
+  }
+  if (currentUserRole === "OWNER") {
+    return true;
+  }
+  return currentUserRole === "ADMIN" && targetRole === "MEMBER";
+}
+
+function roleBadgeVariant(role: TeamRole): "blue" | "green" | "gray" {
+  if (role === "OWNER") return "blue";
+  if (role === "ADMIN") return "green";
+  return "gray";
+}
+
+export function TeamMembersPanel({
+  teamId,
+  teamName,
+  isPersonal,
+  currentUserId,
+  currentUserRole,
+  initialMembers,
+}: TeamMembersPanelProps) {
+  const [members, setMembers] = useState<TeamMember[]>(initialMembers);
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<TeamRole>("MEMBER");
+  const [adding, setAdding] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const canManageMembers = canManage(currentUserRole);
+
+  async function refreshMembers() {
+    const res = await fetch(`/api/teams/${teamId}`);
+    if (!res.ok) return;
+    const data = await res.json();
+    setMembers(data.members || []);
+  }
+
+  async function handleAddOrInvite(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+    setAdding(true);
+
+    try {
+      const res = await fetch(`/api/teams/${teamId}/members`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, role }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Failed to add or invite member");
+        return;
+      }
+
+      if (data.mode === "added") {
+        setSuccess("Existing user added to team");
+        await refreshMembers();
+      } else {
+        setSuccess("Invite sent to email");
+      }
+      setEmail("");
+    } catch {
+      setError("An unexpected error occurred");
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function handleRemoveMember(member: TeamMember) {
+    setError("");
+    setSuccess("");
+    setRemovingId(member.user.id);
+    try {
+      const res = await fetch(`/api/teams/${teamId}/members/${member.user.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to remove member");
+        return;
+      }
+      await refreshMembers();
+    } catch {
+      setError("An unexpected error occurred");
+    } finally {
+      setRemovingId(null);
+    }
+  }
+
+  return (
+    <Card className="h-full">
+      <div className="mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">Team Members</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          {isPersonal ? "Personal Workspace" : teamName} · {members.length} member
+          {members.length !== 1 ? "s" : ""}
+        </p>
+      </div>
+
+      {error && (
+        <div className="mb-3 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="mb-3 rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-700">
+          {success}
+        </div>
+      )}
+
+      <div className="space-y-2 mb-6 max-h-96 overflow-auto pr-1">
+        {members.map((member) => (
+          <div
+            key={member.id}
+            className="rounded-lg border border-gray-100 px-3 py-2 flex items-center justify-between gap-3"
+          >
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-gray-900 truncate">
+                {member.user.name}
+                {member.user.id === currentUserId ? " (You)" : ""}
+              </div>
+              <div className="text-xs text-gray-500 truncate">{member.user.email}</div>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <Badge variant={roleBadgeVariant(member.role)}>{member.role}</Badge>
+              {canManageMembers && canRemoveMember(currentUserRole, member.role) && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  loading={removingId === member.user.id}
+                  onClick={() => handleRemoveMember(member)}
+                  className="text-red-600 hover:text-red-700"
+                >
+                  Remove
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+        {members.length === 0 && (
+          <p className="text-sm text-gray-500">No members found.</p>
+        )}
+      </div>
+
+      {canManageMembers && !isPersonal && (
+        <form onSubmit={handleAddOrInvite} className="space-y-3 border-t border-gray-100 pt-4">
+          <h3 className="text-sm font-semibold text-gray-900">
+            Add Existing User or Invite by Email
+          </h3>
+          <Input
+            label="User Email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="user@example.com"
+            required
+          />
+          <div className="flex items-center gap-2">
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value as TeamRole)}
+              className="h-10 rounded-lg border border-gray-200 px-3 text-sm"
+            >
+              <option value="MEMBER">Member</option>
+              <option value="ADMIN">Admin</option>
+            </select>
+            <Button type="submit" loading={adding} className="flex-1">
+              Add or Invite
+            </Button>
+          </div>
+        </form>
+      )}
+    </Card>
+  );
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -64,6 +64,11 @@ export const UpdateAppInstanceSchema = z.object({
   buttonColor: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional().nullable(),
 });
 
+export const TransferAppSchema = z.object({
+  mode: z.enum(["MOVE", "COPY"]),
+  targetTeamId: z.string().min(1, "targetTeamId is required"),
+});
+
 export type CreateAppInstanceInput = z.infer<typeof CreateAppInstanceSchema>;
 export type UpdateAppInstanceInput = z.infer<typeof UpdateAppInstanceSchema>;
 
@@ -118,6 +123,11 @@ export const CreateInviteSchema = z.object({
 
 export const AcceptInviteSchema = z.object({
   token: z.string().min(1, "Token is required"),
+});
+
+export const AddOrInviteMemberSchema = z.object({
+  email: z.email("Invalid email address"),
+  role: z.enum(["ADMIN", "MEMBER"]),
 });
 
 // Admin schemas

--- a/src/repositories/app-instance.repo.ts
+++ b/src/repositories/app-instance.repo.ts
@@ -112,6 +112,91 @@ export async function deleteAppInstance(id: string): Promise<void> {
   await prisma.appInstance.delete({ where: { id } });
 }
 
+async function generateCopySlug(
+  prisma: PrismaClient,
+  sourceSlug: string,
+): Promise<string> {
+  const base = `${sourceSlug}-copy`;
+  let suffix = 1;
+
+  while (true) {
+    const candidate = suffix === 1 ? base : `${base}-${suffix}`;
+    const existing = await prisma.appInstance.findUnique({
+      where: { slug: candidate },
+      select: { id: true },
+    });
+    if (!existing) {
+      return candidate;
+    }
+    suffix += 1;
+  }
+}
+
+function generateCopyName(sourceName: string, suffix: number): string {
+  return suffix === 1 ? `${sourceName} (Copy)` : `${sourceName} (Copy ${suffix})`;
+}
+
+async function generateCopyNameAndSlug(
+  prisma: PrismaClient,
+  sourceName: string,
+  sourceSlug: string,
+): Promise<{ name: string; slug: string }> {
+  const slug = await generateCopySlug(prisma, sourceSlug);
+  const base = `${sourceSlug}-copy`;
+  const suffixPart = slug.slice(base.length);
+  const suffix = suffixPart.startsWith("-")
+    ? Number.parseInt(suffixPart.slice(1), 10) || 1
+    : 1;
+  return {
+    name: generateCopyName(sourceName, suffix),
+    slug,
+  };
+}
+
+export async function moveAppInstanceToTeam(
+  id: string,
+  targetTeamId: string,
+): Promise<RedactedAppInstance> {
+  const prisma = await getPrisma();
+  const record = await prisma.appInstance.update({
+    where: { id },
+    data: { teamId: targetTeamId },
+  });
+  return redactRecord(record);
+}
+
+export async function copyAppInstanceToTeam(
+  id: string,
+  targetTeamId: string,
+): Promise<RedactedAppInstance> {
+  const prisma = await getPrisma();
+  const source = await getAppInstanceById(id);
+  if (!source) {
+    throw new Error("App instance not found");
+  }
+
+  const { name, slug } = await generateCopyNameAndSlug(
+    prisma,
+    source.name,
+    source.slug,
+  );
+
+  return createAppInstance({
+    name,
+    slug,
+    protocol: source.protocol,
+    teamId: targetTeamId,
+    issuerUrl: source.issuerUrl,
+    clientId: source.clientId,
+    clientSecret: source.clientSecret,
+    scopes: source.scopes,
+    entryPoint: source.entryPoint,
+    issuer: source.issuer,
+    idpCert: source.idpCert,
+    buttonColor: source.buttonColor,
+  });
+}
+
 export async function getRedactedAppInstanceById(
   id: string
 ): Promise<RedactedAppInstance | null> {

--- a/src/repositories/team.repo.ts
+++ b/src/repositories/team.repo.ts
@@ -99,6 +99,13 @@ export async function listTeamMembers(teamId: string) {
   });
 }
 
+export async function countOwners(teamId: string): Promise<number> {
+  const prisma = await getPrisma();
+  return prisma.teamMember.count({
+    where: { teamId, role: "OWNER" },
+  });
+}
+
 export async function countTeams(): Promise<number> {
   const prisma = await getPrisma();
   return prisma.team.count();


### PR DESCRIPTION
## Summary
- move team management into the dashboard with a right-side Team Members panel tied to active team selection
- add dashboard actions to move/copy apps between teams (requires admin/owner on source and target teams)
- add API routes for app transfer, add-or-invite member, and leave team with last-owner protection
- allow team admins (in addition to owners) to delete non-personal teams and update active-team fallback in session
- update settings to focus on team membership + leave actions instead of team management controls
- add Back to Dashboard links on test login and inspector pages
- refresh AGENTS.md and CLAUDE.md helper context to reflect the new architecture

## API Additions
- `POST /api/apps/[id]/transfer`
- `POST /api/teams/[id]/members`
- `POST /api/teams/[id]/leave`

## Validation
- `npm run lint`
- `npx tsc --noEmit`
