### PR TITLE
feat(ui): modern enterprise redesign + system-aware dark mode

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,15 +1,21 @@
+import { ThemeToggle } from "@/components/layout/ThemeToggle";
+
 export default function AuthLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md">
-        <div className="flex items-center justify-center gap-2 mb-8">
-          <div className="w-10 h-10 bg-primary rounded-lg flex items-center justify-center">
+    <div className="relative flex min-h-screen items-center justify-center px-4 py-10">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle compact />
+      </div>
+
+      <div className="w-full max-w-md animate-enter">
+        <div className="mb-8 flex items-center justify-center gap-3">
+          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--primary)] text-white shadow-[var(--shadow-sm)]">
             <svg
-              className="w-6 h-6 text-white"
+              className="h-6 w-6"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -22,7 +28,10 @@ export default function AuthLayout({
               />
             </svg>
           </div>
-          <span className="text-2xl font-bold text-gray-900">AuthLab</span>
+          <div>
+            <p className="text-2xl font-bold tracking-tight text-[var(--text)]">AuthLab</p>
+            <p className="text-xs uppercase tracking-[0.12em] text-[var(--muted)]">Secure Sandbox</p>
+          </div>
         </div>
         {children}
       </div>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -45,13 +45,16 @@ function LoginForm() {
   }
 
   return (
-    <Card>
-      <h1 className="text-xl font-bold text-gray-900 mb-6 text-center">
-        Sign in to AuthLab
+    <Card className="animate-enter">
+      <h1 className="mb-2 text-center text-2xl font-semibold tracking-tight text-[var(--text)]">
+        Sign in
       </h1>
+      <p className="mb-6 text-center text-sm text-[var(--muted)]">
+        Continue to your authentication workspace
+      </p>
 
       {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg">
+        <div className="mb-4 rounded-xl border border-red-300/50 bg-red-100/40 p-3 text-sm text-red-600 dark:border-red-600/40 dark:bg-red-500/10 dark:text-red-300">
           {error}
         </div>
       )}
@@ -78,9 +81,9 @@ function LoginForm() {
         </Button>
       </form>
 
-      <p className="mt-4 text-center text-sm text-gray-500">
+      <p className="mt-5 text-center text-sm text-[var(--muted)]">
         Don&apos;t have an account?{" "}
-        <Link href="/register" className="text-primary hover:underline">
+        <Link href="/register" className="font-medium text-[var(--primary)] hover:underline">
           Register
         </Link>
       </p>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -51,13 +51,16 @@ export default function RegisterPage() {
   }
 
   return (
-    <Card>
-      <h1 className="text-xl font-bold text-gray-900 mb-6 text-center">
-        Create an Account
+    <Card className="animate-enter">
+      <h1 className="mb-2 text-center text-2xl font-semibold tracking-tight text-[var(--text)]">
+        Create account
       </h1>
+      <p className="mb-6 text-center text-sm text-[var(--muted)]">
+        Set up your AuthLab workspace
+      </p>
 
       {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg">
+        <div className="mb-4 rounded-xl border border-red-300/50 bg-red-100/40 p-3 text-sm text-red-600 dark:border-red-600/40 dark:bg-red-500/10 dark:text-red-300">
           {error}
         </div>
       )}
@@ -102,9 +105,9 @@ export default function RegisterPage() {
         </Button>
       </form>
 
-      <p className="mt-4 text-center text-sm text-gray-500">
+      <p className="mt-5 text-center text-sm text-[var(--muted)]">
         Already have an account?{" "}
-        <Link href="/login" className="text-primary hover:underline">
+        <Link href="/login" className="font-medium text-[var(--primary)] hover:underline">
           Sign in
         </Link>
       </p>

--- a/src/app/(dashboard)/admin/settings/page.tsx
+++ b/src/app/(dashboard)/admin/settings/page.tsx
@@ -69,103 +69,69 @@ export default function AdminSettingsPage() {
       body: JSON.stringify({ isSystemAdmin: !current }),
     });
     setUsers((prev) =>
-      prev.map((u) =>
-        u.id === userId ? { ...u, isSystemAdmin: !current } : u,
-      ),
+      prev.map((u) => (u.id === userId ? { ...u, isSystemAdmin: !current } : u)),
     );
   }
 
   if (loading) {
-    return (
-      <div className="flex justify-center py-12 text-gray-500">Loading...</div>
-    );
+    return <div className="py-12 text-center text-[var(--muted)]">Loading...</div>;
   }
 
   return (
-    <div className="max-w-4xl mx-auto space-y-6">
-      <h1 className="text-2xl font-bold text-gray-900">Admin Settings</h1>
+    <div className="mx-auto max-w-5xl space-y-6 animate-enter">
+      <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)]">Admin Settings</h1>
 
-      {/* Stats */}
       {stats && (
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <Card>
-            <div className="text-3xl font-bold text-gray-900">
-              {stats.totalUsers}
-            </div>
-            <div className="text-sm text-gray-500">Total Users</div>
+            <div className="text-3xl font-bold text-[var(--text)]">{stats.totalUsers}</div>
+            <div className="text-sm text-[var(--muted)]">Total Users</div>
           </Card>
           <Card>
-            <div className="text-3xl font-bold text-gray-900">
-              {stats.totalTeams}
-            </div>
-            <div className="text-sm text-gray-500">Total Teams</div>
+            <div className="text-3xl font-bold text-[var(--text)]">{stats.totalTeams}</div>
+            <div className="text-sm text-[var(--muted)]">Total Teams</div>
           </Card>
           <Card>
-            <div className="text-3xl font-bold text-gray-900">
-              {stats.totalApps}
-            </div>
-            <div className="text-sm text-gray-500">Total Apps</div>
+            <div className="text-3xl font-bold text-[var(--text)]">{stats.totalApps}</div>
+            <div className="text-sm text-[var(--muted)]">Total Apps</div>
           </Card>
         </div>
       )}
 
-      {/* System Settings */}
       <Card>
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">
-          System Settings
-        </h2>
-        <div className="space-y-3">
-          <div className="flex items-center justify-between py-2">
-            <div>
-              <div className="font-medium text-gray-900">
-                Open Registration
-              </div>
-              <div className="text-sm text-gray-500">
-                Allow new users to register accounts
-              </div>
-            </div>
-            <button
-              onClick={() =>
-                toggleSetting(
-                  "registrationEnabled",
-                  settings.registrationEnabled || "true",
-                )
-              }
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                (settings.registrationEnabled || "true") === "true"
-                  ? "bg-primary"
-                  : "bg-gray-300"
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                  (settings.registrationEnabled || "true") === "true"
-                    ? "translate-x-6"
-                    : "translate-x-1"
-                }`}
-              />
-            </button>
+        <h2 className="mb-4 text-lg font-semibold text-[var(--text)]">System Settings</h2>
+        <div className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3">
+          <div>
+            <div className="font-medium text-[var(--text)]">Open Registration</div>
+            <div className="text-sm text-[var(--muted)]">Allow new users to register accounts</div>
           </div>
+          <button
+            onClick={() =>
+              toggleSetting(
+                "registrationEnabled",
+                settings.registrationEnabled || "true",
+              )
+            }
+            className={`focus-ring relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${(settings.registrationEnabled || "true") === "true" ? "bg-[var(--primary)]" : "bg-[var(--border-strong)]"}`}
+          >
+            <span
+              className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${(settings.registrationEnabled || "true") === "true" ? "translate-x-6" : "translate-x-1"}`}
+            />
+          </button>
         </div>
       </Card>
 
-      {/* Users */}
       <Card>
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">
-          Users ({users.length})
-        </h2>
-        <div className="divide-y divide-gray-100">
+        <h2 className="mb-4 text-lg font-semibold text-[var(--text)]">Users ({users.length})</h2>
+        <div className="space-y-2">
           {users.map((user) => (
-            <div
-              key={user.id}
-              className="flex items-center justify-between py-3"
-            >
+            <div key={user.id} className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2.5">
               <div>
                 <div className="flex items-center gap-2">
-                  <span className="font-medium text-gray-900">{user.name}</span>
+                  <span className="font-medium text-[var(--text)]">{user.name}</span>
                   {user.isSystemAdmin && <Badge variant="blue">Admin</Badge>}
                 </div>
-                <div className="text-sm text-gray-500">
+                <div className="text-sm text-[var(--muted)]">
                   {user.email} · {user._count.teamMemberships} team
                   {user._count.teamMemberships !== 1 ? "s" : ""}
                 </div>
@@ -182,28 +148,18 @@ export default function AdminSettingsPage() {
         </div>
       </Card>
 
-      {/* Teams */}
       <Card>
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">
-          Teams ({teams.length})
-        </h2>
-        <div className="divide-y divide-gray-100">
+        <h2 className="mb-4 text-lg font-semibold text-[var(--text)]">Teams ({teams.length})</h2>
+        <div className="space-y-2">
           {teams.map((team) => (
-            <div
-              key={team.id}
-              className="flex items-center justify-between py-3"
-            >
+            <div key={team.id} className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2.5">
               <div>
                 <div className="flex items-center gap-2">
-                  <span className="font-medium text-gray-900">{team.name}</span>
-                  {team.isPersonal && (
-                    <span className="text-xs text-gray-400">(Personal)</span>
-                  )}
+                  <span className="font-medium text-[var(--text)]">{team.name}</span>
+                  {team.isPersonal && <span className="text-xs text-[var(--muted)]">(Personal)</span>}
                 </div>
-                <div className="text-sm text-gray-500">
-                  {team._count.members} member
-                  {team._count.members !== 1 ? "s" : ""} ·{" "}
-                  {team._count.appInstances} app
+                <div className="text-sm text-[var(--muted)]">
+                  {team._count.members} member{team._count.members !== 1 ? "s" : ""} · {team._count.appInstances} app
                   {team._count.appInstances !== 1 ? "s" : ""}
                 </div>
               </div>

--- a/src/app/(dashboard)/apps/[id]/page.tsx
+++ b/src/app/(dashboard)/apps/[id]/page.tsx
@@ -17,17 +17,17 @@ export default async function EditAppPage({
     notFound();
   }
 
-  // Verify user has access to this app's team
   const membership = await getTeamMembership(user.userId, app.teamId);
   if (!membership) {
     notFound();
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">
-        Edit: {app.name}
-      </h1>
+    <div className="mx-auto max-w-3xl space-y-4 animate-enter">
+      <div>
+        <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)]">Edit {app.name}</h1>
+        <p className="text-sm text-[var(--muted)]">Adjust provider settings and test UI behavior.</p>
+      </div>
       <EditAppForm app={app} />
     </div>
   );

--- a/src/app/(dashboard)/apps/new/page.tsx
+++ b/src/app/(dashboard)/apps/new/page.tsx
@@ -2,10 +2,13 @@ import { CreationStepper } from "@/components/apps/CreationStepper";
 
 export default function NewAppPage() {
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-        Create New App Instance
-      </h1>
+    <div className="space-y-6 animate-enter">
+      <div className="text-center">
+        <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)]">Create New App Instance</h1>
+        <p className="mt-1 text-sm text-[var(--muted)]">
+          Configure protocol, metadata, and test experience
+        </p>
+      </div>
       <CreationStepper />
     </div>
   );

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -21,20 +21,23 @@ export default async function HomePage() {
   const members = team ? await listTeamMembers(team.id) : [];
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-          {team && (
-            <p className="text-sm text-gray-500 mt-1">
-              Active team: {team.isPersonal ? "Personal Workspace" : team.name}
-            </p>
-          )}
+    <div className="space-y-6 animate-enter">
+      <div className="surface-panel rounded-2xl p-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)]">Dashboard</h1>
+            {team && (
+              <p className="mt-1 text-sm text-[var(--muted)]">
+                Active team: {team.isPersonal ? "Personal Workspace" : team.name}
+              </p>
+            )}
+          </div>
+          <Link href="/apps/new">
+            <Button>Create New App</Button>
+          </Link>
         </div>
-        <Link href="/apps/new">
-          <Button>Create New App</Button>
-        </Link>
       </div>
+
       <Dashboard
         key={user.activeTeamId}
         initialApps={apps}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -122,134 +122,80 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto space-y-6">
-      <h1 className="text-2xl font-bold text-gray-900">Settings</h1>
+    <div className="mx-auto max-w-3xl space-y-6 animate-enter">
+      <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)]">Settings</h1>
 
       {error && (
-        <div className="p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg">
+        <div className="rounded-xl border border-red-300/50 bg-red-100/40 p-3 text-sm text-red-600 dark:border-red-600/40 dark:bg-red-500/10 dark:text-red-300">
           {error}
         </div>
       )}
       {success && (
-        <div className="p-3 bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg">
+        <div className="rounded-xl border border-emerald-300/50 bg-emerald-100/40 p-3 text-sm text-emerald-700 dark:border-emerald-600/40 dark:bg-emerald-500/10 dark:text-emerald-200">
           {success}
         </div>
       )}
 
-      {/* Profile */}
       <Card>
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Profile</h2>
+        <h2 className="mb-4 text-lg font-semibold text-[var(--text)]">Profile</h2>
         <form onSubmit={handleProfile} className="space-y-4">
-          <Input
-            label="Name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-          />
-          <Input
-            label="Email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
+          <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} required />
+          <Input label="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
           <div className="flex justify-end">
-            <Button type="submit" loading={loading}>
-              Save Changes
-            </Button>
+            <Button type="submit" loading={loading}>Save Changes</Button>
           </div>
         </form>
       </Card>
 
-      {/* Password */}
       <Card>
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">
-          Change Password
-        </h2>
+        <h2 className="mb-4 text-lg font-semibold text-[var(--text)]">Change Password</h2>
         <form onSubmit={handlePassword} className="space-y-4">
-          <Input
-            label="Current Password"
-            type="password"
-            value={currentPassword}
-            onChange={(e) => setCurrentPassword(e.target.value)}
-            required
-          />
-          <Input
-            label="New Password"
-            type="password"
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-            required
-            minLength={8}
-          />
-          <Input
-            label="Confirm New Password"
-            type="password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            required
-            minLength={8}
-          />
+          <Input label="Current Password" type="password" value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} required />
+          <Input label="New Password" type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required minLength={8} />
+          <Input label="Confirm New Password" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required minLength={8} />
           <div className="flex justify-end">
-            <Button type="submit" loading={loading}>
-              Update Password
-            </Button>
+            <Button type="submit" loading={loading}>Update Password</Button>
           </div>
         </form>
       </Card>
 
-      {/* Teams */}
       <Card>
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">
-          Team Memberships
-        </h2>
-        <div className="divide-y divide-gray-100">
+        <h2 className="mb-4 text-lg font-semibold text-[var(--text)]">Team Memberships</h2>
+        <div className="space-y-2">
           {user.teams.map((team) => (
-            <div
-              key={team.id}
-              className="flex items-center justify-between py-3"
-            >
+            <div key={team.id} className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2.5">
               <div>
-                <div className="font-medium text-gray-900">
-                  {team.isPersonal ? "Personal Workspace" : team.name}
-                </div>
-                <div className="text-sm text-gray-500">
+                <div className="font-medium text-[var(--text)]">{team.isPersonal ? "Personal Workspace" : team.name}</div>
+                <div className="text-sm text-[var(--muted)]">
                   <span className="mr-2">{team.role}</span>· {team.memberCount} member
-                  {team.memberCount !== 1 ? "s" : ""} ·{" "}
-                  {team.appCount} app{team.appCount !== 1 ? "s" : ""}
+                  {team.memberCount !== 1 ? "s" : ""} · {team.appCount} app
+                  {team.appCount !== 1 ? "s" : ""}
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                {team.id === user.activeTeamId && (
-                  <Badge variant="blue">Active</Badge>
-                )}
+                {team.id === user.activeTeamId && <Badge variant="blue">Active</Badge>}
                 {!team.isPersonal && (
                   <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => handleLeaveTeam(team.id)}
                     loading={leavingTeamId === team.id}
-                    className="text-red-600 hover:text-red-700"
+                    className="text-[var(--danger)]"
                   >
                     Leave
                   </Button>
                 )}
-                {team.isPersonal && (
-                  <Badge variant="gray">Required</Badge>
-                )}
+                {team.isPersonal && <Badge variant="gray">Required</Badge>}
               </div>
             </div>
           ))}
         </div>
       </Card>
 
-      <Card>
-        <h2 className="text-lg font-semibold text-gray-900 mb-2">
-          Team Management
-        </h2>
-        <p className="text-sm text-gray-500">
-          Team member management and invites are available directly on the dashboard
-          for the currently active team.
+      <Card tone="subtle">
+        <h2 className="mb-2 text-lg font-semibold text-[var(--text)]">Team Management</h2>
+        <p className="text-sm text-[var(--muted)]">
+          Team member management and invites are available directly on the dashboard for the active team.
         </p>
       </Card>
     </div>

--- a/src/app/(dashboard)/teams/[id]/page.tsx
+++ b/src/app/(dashboard)/teams/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useUser } from "@/components/providers/UserProvider";
 import { Button } from "@/components/ui/Button";
@@ -40,12 +40,10 @@ export default function TeamDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
-  // Invite form
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState("MEMBER");
   const [inviting, setInviting] = useState(false);
 
-  // Delete modal
   const [showDelete, setShowDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -54,19 +52,19 @@ export default function TeamDetailPage() {
     ? currentTeam.role === "OWNER" || currentTeam.role === "ADMIN"
     : false;
 
-  async function fetchTeam() {
+  const fetchTeam = useCallback(async () => {
     const res = await fetch(`/api/teams/${id}`);
     if (res.ok) {
       setTeam(await res.json());
     }
-  }
+  }, [id]);
 
-  async function fetchInvites() {
+  const fetchInvites = useCallback(async () => {
     const res = await fetch(`/api/teams/${id}/invites`);
     if (res.ok) {
       setInvites(await res.json());
     }
-  }
+  }, [id]);
 
   useEffect(() => {
     const requests = [fetchTeam()];
@@ -74,8 +72,7 @@ export default function TeamDetailPage() {
       requests.push(fetchInvites());
     }
     Promise.all(requests).finally(() => setLoading(false));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, canManage]);
+  }, [canManage, fetchInvites, fetchTeam]);
 
   async function handleInvite(e: React.FormEvent) {
     e.preventDefault();
@@ -138,23 +135,20 @@ export default function TeamDetailPage() {
   }
 
   if (loading) {
-    return (
-      <div className="flex justify-center py-12 text-gray-500">Loading...</div>
-    );
+    return <div className="py-12 text-center text-[var(--muted)]">Loading...</div>;
   }
 
   if (!team) {
-    return (
-      <div className="flex justify-center py-12 text-gray-500">
-        Team not found
-      </div>
-    );
+    return <div className="py-12 text-center text-[var(--muted)]">Team not found</div>;
   }
 
   return (
-    <div className="max-w-2xl mx-auto space-y-6">
+    <div className="mx-auto max-w-3xl space-y-6 animate-enter">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">{team.name}</h1>
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)]">{team.name}</h1>
+          <p className="text-sm text-[var(--muted)]">Manage members, invites, and team roles.</p>
+        </div>
         {!team.isPersonal && canManage && (
           <Button variant="danger" size="sm" onClick={() => setShowDelete(true)}>
             Delete Team
@@ -163,71 +157,60 @@ export default function TeamDetailPage() {
       </div>
 
       {error && (
-        <div className="p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg">
+        <div className="rounded-xl border border-red-300/50 bg-red-100/40 p-3 text-sm text-red-600 dark:border-red-600/40 dark:bg-red-500/10 dark:text-red-300">
           {error}
         </div>
       )}
 
-      {/* Members */}
       <Card>
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Members</h2>
-        <div className="divide-y divide-gray-100">
+        <h2 className="mb-4 text-lg font-semibold text-[var(--text)]">Members</h2>
+        <div className="space-y-2">
           {team.members.map((member) => (
-            <div
-              key={member.id}
-              className="flex items-center justify-between py-3"
-            >
-              <div>
-                <div className="font-medium text-gray-900">
-                  {member.user.name}
+            <div key={member.id} className="rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2.5">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="font-medium text-[var(--text)]">{member.user.name}</div>
+                  <div className="text-sm text-[var(--muted)]">{member.user.email}</div>
                 </div>
-                <div className="text-sm text-gray-500">{member.user.email}</div>
-              </div>
-              <div className="flex items-center gap-2">
-                {member.role === "OWNER" ? (
-                  <Badge variant="blue">Owner</Badge>
-                ) : (
-                  <>
-                    {canManage ? (
-                      <>
-                        <select
-                          value={member.role}
-                          onChange={(e) =>
-                            handleRoleChange(member.user.id, e.target.value)
-                          }
-                          className="text-sm border border-gray-200 rounded px-2 py-1"
-                        >
-                          <option value="ADMIN">Admin</option>
-                          <option value="MEMBER">Member</option>
-                        </select>
-                        <button
-                          onClick={() => handleRemoveMember(member.user.id)}
-                          className="text-sm text-red-600 hover:text-red-800"
-                        >
-                          Remove
-                        </button>
-                      </>
-                    ) : (
-                      <Badge variant={member.role === "ADMIN" ? "green" : "gray"}>
-                        {member.role}
-                      </Badge>
-                    )}
-                  </>
-                )}
+                <div className="flex items-center gap-2">
+                  {member.role === "OWNER" ? (
+                    <Badge variant="blue">Owner</Badge>
+                  ) : canManage ? (
+                    <>
+                      <select
+                        value={member.role}
+                        onChange={(e) => handleRoleChange(member.user.id, e.target.value)}
+                        className="focus-ring h-9 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-2 text-sm text-[var(--text)]"
+                      >
+                        <option value="ADMIN">Admin</option>
+                        <option value="MEMBER">Member</option>
+                      </select>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-[var(--danger)]"
+                        onClick={() => handleRemoveMember(member.user.id)}
+                      >
+                        Remove
+                      </Button>
+                    </>
+                  ) : (
+                    <Badge variant={member.role === "ADMIN" ? "green" : "gray"}>
+                      {member.role}
+                    </Badge>
+                  )}
+                </div>
               </div>
             </div>
           ))}
         </div>
       </Card>
 
-      {/* Invite */}
       {!team.isPersonal && canManage && (
         <Card>
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
-            Invite Members
-          </h2>
-          <form onSubmit={handleInvite} className="flex gap-3 items-end">
-            <div className="flex-1">
+          <h2 className="mb-4 text-lg font-semibold text-[var(--text)]">Invite Members</h2>
+          <form onSubmit={handleInvite} className="flex flex-col items-end gap-3 md:flex-row">
+            <div className="w-full flex-1">
               <Input
                 label="Email"
                 type="email"
@@ -240,41 +223,32 @@ export default function TeamDetailPage() {
             <select
               value={inviteRole}
               onChange={(e) => setInviteRole(e.target.value)}
-              className="h-10 border border-gray-200 rounded-lg px-3 text-sm"
+              className="focus-ring h-11 w-full rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--text)] md:w-auto"
             >
               <option value="MEMBER">Member</option>
               <option value="ADMIN">Admin</option>
             </select>
-            <Button type="submit" loading={inviting}>
-              Invite
-            </Button>
+            <Button type="submit" loading={inviting}>Invite</Button>
           </form>
 
           {invites.length > 0 && (
             <div className="mt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-2">
-                Pending Invites
-              </h3>
-              <div className="divide-y divide-gray-100">
+              <h3 className="mb-2 text-sm font-medium text-[var(--text)]">Pending Invites</h3>
+              <div className="space-y-2">
                 {invites.map((invite) => (
-                  <div
-                    key={invite.id}
-                    className="flex items-center justify-between py-2"
-                  >
+                  <div key={invite.id} className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2">
                     <div>
-                      <span className="text-sm text-gray-900">
-                        {invite.email}
-                      </span>
-                      <span className="text-xs text-gray-500 ml-2">
-                        ({invite.role})
-                      </span>
+                      <span className="text-sm text-[var(--text)]">{invite.email}</span>
+                      <span className="ml-2 text-xs text-[var(--muted)]">({invite.role})</span>
                     </div>
-                    <button
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-[var(--danger)]"
                       onClick={() => handleRevokeInvite(invite.id)}
-                      className="text-xs text-red-600 hover:text-red-800"
                     >
                       Revoke
-                    </button>
+                    </Button>
                   </div>
                 ))}
               </div>
@@ -283,17 +257,12 @@ export default function TeamDetailPage() {
         </Card>
       )}
 
-      {/* Delete Modal */}
-      <Modal
-        isOpen={showDelete}
-        onClose={() => setShowDelete(false)}
-        title="Delete Team"
-      >
-        <p className="text-sm text-gray-600 mb-4">
-          This will permanently delete the team &quot;{team.name}&quot; and all its app
-          instances. This action cannot be undone.
+      <Modal isOpen={showDelete} onClose={() => setShowDelete(false)} title="Delete Team">
+        <p className="mb-4 text-sm text-[var(--muted)]">
+          This will permanently delete the team &quot;{team.name}&quot; and all app instances.
+          This action cannot be undone.
         </p>
-        <div className="flex gap-3 justify-end">
+        <div className="flex justify-end gap-3">
           <Button variant="secondary" onClick={() => setShowDelete(false)}>
             Cancel
           </Button>

--- a/src/app/(dashboard)/teams/new/page.tsx
+++ b/src/app/(dashboard)/teams/new/page.tsx
@@ -46,7 +46,6 @@ export default function NewTeamPage() {
 
       const team = await res.json();
 
-      // Switch to the new team
       await fetch("/api/teams/switch", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -63,11 +62,15 @@ export default function NewTeamPage() {
   }
 
   return (
-    <div className="max-w-lg mx-auto">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">Create a Team</h1>
+    <div className="mx-auto max-w-lg space-y-4 animate-enter">
+      <div>
+        <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)]">Create Team</h1>
+        <p className="text-sm text-[var(--muted)]">Set up a shared workspace for apps and members.</p>
+      </div>
+
       <Card>
         {error && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg">
+          <div className="mb-4 rounded-xl border border-red-300/50 bg-red-100/40 p-3 text-sm text-red-600 dark:border-red-600/40 dark:bg-red-500/10 dark:text-red-300">
             {error}
           </div>
         )}
@@ -91,7 +94,7 @@ export default function NewTeamPage() {
             placeholder="my-team"
             helperText="URL-friendly identifier (lowercase, hyphens only)"
           />
-          <div className="flex gap-3 justify-end">
+          <div className="flex justify-end gap-3">
             <Button
               type="button"
               variant="secondary"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,21 +1,150 @@
 @import "tailwindcss";
 
 @theme inline {
-  --color-primary: #3B71CA;
-  --color-primary-dark: #2B5AA8;
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --color-primary: var(--primary);
+  --color-primary-dark: var(--primary-strong);
+  --color-background: var(--bg);
+  --color-foreground: var(--text);
+  --font-sans: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+  --font-mono: "IBM Plex Mono", "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
 }
 
 :root {
-  --background: #f8fafc;
-  --foreground: #1e293b;
+  --primary: #3b71ca;
+  --primary-strong: #2f5ea8;
+  --success: #0f766e;
+  --warning: #b45309;
+  --danger: #b42318;
+  --ring: color-mix(in oklab, var(--primary) 45%, transparent);
+
+  --bg: #f3f7fc;
+  --surface: #ffffff;
+  --surface-2: #eef3fa;
+  --surface-inverse: #112237;
+  --text: #102135;
+  --muted: #5d6d82;
+  --border: #d5dfeb;
+  --border-strong: #c0cddd;
+
+  --shadow-xs: 0 1px 2px rgb(15 23 42 / 0.05);
+  --shadow-sm: 0 4px 16px rgb(15 23 42 / 0.08);
+  --shadow-md: 0 10px 32px rgb(15 23 42 / 0.12);
+
+  --code-bg: #0f172a;
+  --code-text: #dbe8ff;
+
+  color-scheme: light;
+}
+
+[data-theme="dark"] {
+  --primary: #76a8ff;
+  --primary-strong: #96beff;
+  --success: #2dd4bf;
+  --warning: #f59e0b;
+  --danger: #f87171;
+  --ring: color-mix(in oklab, var(--primary) 55%, transparent);
+
+  --bg: #090f1a;
+  --surface: #101a2b;
+  --surface-2: #162439;
+  --surface-inverse: #d8e5fb;
+  --text: #dce9fb;
+  --muted: #95a8c0;
+  --border: #21324b;
+  --border-strong: #2a4161;
+
+  --shadow-xs: 0 1px 2px rgb(0 0 0 / 0.35);
+  --shadow-sm: 0 8px 24px rgb(0 0 0 / 0.32);
+  --shadow-md: 0 16px 44px rgb(0 0 0 / 0.45);
+
+  --code-bg: #050b15;
+  --code-text: #cfe0ff;
+
+  color-scheme: dark;
+}
+
+[data-theme="light"] {
+  color-scheme: light;
+}
+
+* {
+  border-color: var(--border);
+}
+
+html,
+body {
+  min-height: 100%;
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
+  background:
+    radial-gradient(circle at 0% 0%, color-mix(in oklab, var(--primary) 12%, transparent) 0%, transparent 44%),
+    radial-gradient(circle at 100% 0%, color-mix(in oklab, var(--success) 8%, transparent) 0%, transparent 40%),
+    var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+}
+
+a {
+  color: var(--primary);
+}
+
+a:hover {
+  color: var(--primary-strong);
+}
+
+::selection {
+  background: color-mix(in oklab, var(--primary) 26%, transparent);
+  color: var(--text);
+}
+
+.surface-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+}
+
+.surface-subtle {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+}
+
+.text-muted {
+  color: var(--muted);
+}
+
+.focus-ring {
+  outline: none;
+}
+
+.focus-ring:focus-visible {
+  box-shadow: 0 0 0 3px var(--ring);
+}
+
+@keyframes enter-rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .animate-enter {
+    animation: enter-rise 320ms ease-out both;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
+import { ThemeToggle } from "@/components/layout/ThemeToggle";
 
 export default function AcceptInvitePage() {
   const { token } = useParams<{ token: string }>();
@@ -13,11 +14,9 @@ export default function AcceptInvitePage() {
   const [result, setResult] = useState<{ teamName: string; role: string } | null>(null);
 
   useEffect(() => {
-    // Check if user is authenticated
     fetch("/api/user/me")
       .then((res) => {
         if (!res.ok) {
-          // Redirect to login with return to this page
           router.push(`/login?redirect=/invite/${token}`);
           return;
         }
@@ -50,7 +49,6 @@ export default function AcceptInvitePage() {
       setResult({ teamName: data.teamName, role: data.role });
       setStatus("done");
 
-      // Switch to the new team
       await fetch("/api/teams/switch", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -63,20 +61,20 @@ export default function AcceptInvitePage() {
   }
 
   if (status === "loading") {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="text-gray-500">Loading...</div>
-      </div>
-    );
+    return <div className="flex min-h-screen items-center justify-center text-[var(--muted)]">Loading...</div>;
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md">
-        <div className="flex items-center justify-center gap-2 mb-8">
-          <div className="w-10 h-10 bg-primary rounded-lg flex items-center justify-center">
+    <div className="relative flex min-h-screen items-center justify-center px-4 py-10">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle compact />
+      </div>
+
+      <div className="w-full max-w-md animate-enter">
+        <div className="mb-8 flex items-center justify-center gap-3">
+          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--primary)] text-white shadow-[var(--shadow-sm)]">
             <svg
-              className="w-6 h-6 text-white"
+              className="h-6 w-6"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -89,52 +87,44 @@ export default function AcceptInvitePage() {
               />
             </svg>
           </div>
-          <span className="text-2xl font-bold text-gray-900">AuthLab</span>
+          <span className="text-2xl font-bold tracking-tight text-[var(--text)]">AuthLab</span>
         </div>
 
         <Card>
           {status === "done" && result ? (
             <div className="text-center">
-              <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg className="w-6 h-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-emerald-500/40 bg-emerald-500/15 text-emerald-500">
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                 </svg>
               </div>
-              <h1 className="text-xl font-bold text-gray-900 mb-2">
-                You&apos;ve joined {result.teamName}!
+              <h1 className="mb-2 text-xl font-semibold text-[var(--text)]">
+                You&apos;ve joined {result.teamName}
               </h1>
-              <p className="text-sm text-gray-500 mb-4">
+              <p className="mb-4 text-sm text-[var(--muted)]">
                 You&apos;ve been added as {result.role.toLowerCase()}.
               </p>
               <Button onClick={() => router.push("/")}>Go to Dashboard</Button>
             </div>
           ) : (
             <>
-              <h1 className="text-xl font-bold text-gray-900 mb-4 text-center">
-                Team Invitation
-              </h1>
+              <h1 className="mb-4 text-center text-xl font-semibold text-[var(--text)]">Team Invitation</h1>
 
               {error && (
-                <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg">
+                <div className="mb-4 rounded-xl border border-red-300/50 bg-red-100/40 p-3 text-sm text-red-600 dark:border-red-600/40 dark:bg-red-500/10 dark:text-red-300">
                   {error}
                 </div>
               )}
 
-              <p className="text-sm text-gray-600 mb-6 text-center">
+              <p className="mb-6 text-center text-sm text-[var(--muted)]">
                 You&apos;ve been invited to join a team on AuthLab.
               </p>
 
-              <div className="flex gap-3 justify-center">
-                <Button
-                  variant="secondary"
-                  onClick={() => router.push("/")}
-                >
+              <div className="flex justify-center gap-3">
+                <Button variant="secondary" onClick={() => router.push("/")}>
                   Decline
                 </Button>
-                <Button
-                  onClick={handleAccept}
-                  loading={status === "accepting"}
-                >
+                <Button onClick={handleAccept} loading={status === "accepting"}>
                   Accept Invitation
                 </Button>
               </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,22 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+const themeScript = `
+(() => {
+  try {
+    const key = "authlab-theme-mode";
+    const stored = localStorage.getItem(key);
+    const mode = stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
+    const systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const resolved = mode === "system" ? (systemDark ? "dark" : "light") : mode;
+    document.documentElement.dataset.theme = resolved;
+    document.documentElement.dataset.themeMode = mode;
+  } catch {
+    document.documentElement.dataset.theme = "light";
+    document.documentElement.dataset.themeMode = "system";
+  }
+})();`;
 
 export const metadata: Metadata = {
   title: "AuthLab — Multi-Tenant Auth Testing Workbench",
@@ -24,11 +30,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
+      <body className="antialiased">
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/test/[slug]/inspector/page.tsx
+++ b/src/app/test/[slug]/inspector/page.tsx
@@ -6,6 +6,7 @@ import { ClaimsTable } from "@/components/inspector/ClaimsTable";
 import { RawPayloadView } from "@/components/inspector/RawPayloadView";
 import { JWTDecoder } from "@/components/inspector/JWTDecoder";
 import { SessionInfo } from "@/components/inspector/SessionInfo";
+import { ThemeToggle } from "@/components/layout/ThemeToggle";
 
 export default async function InspectorPage({
   params,
@@ -26,7 +27,6 @@ export default async function InspectorPage({
     },
   ];
 
-  // Raw data tab
   if (session.protocol === "OIDC" && session.rawToken) {
     tabs.push({
       label: "Raw Token",
@@ -40,7 +40,6 @@ export default async function InspectorPage({
     });
   }
 
-  // JWT decoder (OIDC only)
   if (session.protocol === "OIDC" && session.idToken) {
     tabs.push({
       label: "JWT Decoder",
@@ -49,12 +48,18 @@ export default async function InspectorPage({
   }
 
   return (
-    <div className="max-w-4xl mx-auto">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-2xl font-bold text-gray-900">Auth Inspector</h1>
-        <Link href="/" className="text-sm text-primary hover:underline">
-          Back to Dashboard
-        </Link>
+    <div className="mx-auto max-w-5xl space-y-4 px-4 py-6 animate-enter">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)]">Auth Inspector</h1>
+          <p className="text-sm text-[var(--muted)]">Inspect claims, tokens, and session context</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <ThemeToggle compact />
+          <Link href="/" className="text-sm font-medium text-[var(--primary)] hover:underline">
+            Back to Dashboard
+          </Link>
+        </div>
       </div>
 
       <SessionInfo
@@ -63,9 +68,7 @@ export default async function InspectorPage({
         authenticatedAt={session.authenticatedAt}
       />
 
-      <div className="mt-6">
-        <Tabs tabs={tabs} />
-      </div>
+      <Tabs tabs={tabs} appearance="pill" />
     </div>
   );
 }

--- a/src/app/test/[slug]/page.tsx
+++ b/src/app/test/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { getAppInstanceBySlug } from "@/repositories/app-instance.repo";
 import { Badge } from "@/components/ui/Badge";
 import { Card } from "@/components/ui/Card";
 import { CopyButton } from "@/components/ui/CopyButton";
+import { ThemeToggle } from "@/components/layout/ThemeToggle";
 
 export default async function TestPage({
   params,
@@ -28,76 +29,66 @@ export default async function TestPage({
       : null;
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[60vh]">
-      <Card className="max-w-md w-full text-center">
-        <Badge variant={app.protocol.toLowerCase() as "oidc" | "saml"} />
-        <h1 className="text-2xl font-bold text-gray-900 mt-3 mb-2">
-          {app.name}
-        </h1>
-        <p className="text-sm text-gray-500 mb-6">
-          Test {app.protocol} authentication flow
-        </p>
+    <div className="mx-auto flex min-h-[70vh] max-w-2xl flex-col justify-center px-4 py-8">
+      <div className="mb-4 flex justify-end">
+        <ThemeToggle compact />
+      </div>
+
+      <Card className="animate-enter text-center">
+        <Badge variant={app.protocol.toLowerCase() as "oidc" | "saml"} className="mx-auto" />
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-[var(--text)]">{app.name}</h1>
+        <p className="mb-6 text-sm text-[var(--muted)]">Test {app.protocol} authentication flow</p>
 
         <Link href={`/test/${slug}/login`}>
           <button
-            className="w-full py-3 px-6 rounded-lg text-white font-medium text-lg transition-opacity hover:opacity-90"
+            className="focus-ring w-full rounded-xl px-6 py-3 text-lg font-semibold text-white shadow-[var(--shadow-sm)] transition-opacity hover:opacity-90"
             style={{ backgroundColor: app.buttonColor || "#3B71CA" }}
           >
             Login with {app.protocol}
           </button>
         </Link>
 
-        <Link
-          href="/"
-          className="mt-3 inline-block text-sm text-primary hover:underline"
-        >
+        <Link href="/" className="mt-3 inline-block text-sm font-medium text-[var(--primary)] hover:underline">
           Back to Dashboard
         </Link>
 
-        <div className="mt-6 pt-4 border-t border-gray-100">
-          <p className="text-xs text-gray-400 mb-1">Callback URL</p>
-          <code className="text-xs text-gray-600 bg-gray-50 px-2 py-1 rounded break-all">
+        <div className="mt-6 border-t border-[var(--border)] pt-4 text-left">
+          <p className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">Callback URL</p>
+          <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
             {callbackUrl}
           </code>
-          <p className="text-xs text-gray-400 mt-3">
+          <p className="mt-3 text-xs text-[var(--muted)]">
             Register this URL as the redirect URI in your IdP configuration.
           </p>
 
           {app.protocol === "SAML" && unsignedMetadataUrl && signedMetadataUrl && (
-            <div className="mt-4 space-y-3 text-left">
+            <div className="mt-4 space-y-3">
               <div>
-                <p className="text-xs text-gray-400 mb-1">SP Metadata URL (Unsigned)</p>
-                <code className="block text-xs text-gray-600 bg-gray-50 px-2 py-1 rounded break-all">
+                <p className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">SP Metadata URL (Unsigned)</p>
+                <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
                   {unsignedMetadataUrl}
                 </code>
-                <div className="flex items-center gap-3 mt-1">
+                <div className="mt-1 flex items-center gap-3">
                   <CopyButton text={unsignedMetadataUrl} />
-                  <a
-                    href={unsignedMetadataUrl}
-                    className="text-xs text-primary hover:underline"
-                  >
+                  <a href={unsignedMetadataUrl} className="text-xs text-[var(--primary)] hover:underline">
                     Download
                   </a>
                 </div>
               </div>
               <div>
-                <p className="text-xs text-gray-400 mb-1">SP Metadata URL (Signed)</p>
-                <code className="block text-xs text-gray-600 bg-gray-50 px-2 py-1 rounded break-all">
+                <p className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">SP Metadata URL (Signed)</p>
+                <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
                   {signedMetadataUrl}
                 </code>
-                <div className="flex items-center gap-3 mt-1">
+                <div className="mt-1 flex items-center gap-3">
                   <CopyButton text={signedMetadataUrl} />
-                  <a
-                    href={signedMetadataUrl}
-                    className="text-xs text-primary hover:underline"
-                  >
+                  <a href={signedMetadataUrl} className="text-xs text-[var(--primary)] hover:underline">
                     Download
                   </a>
                 </div>
               </div>
-              <p className="text-xs text-gray-400">
-                Signed metadata requires both <code>SAML_SP_PRIVATE_KEY</code> and{" "}
-                <code>SAML_SP_PUBLIC_CERT</code> environment variables.
+              <p className="text-xs text-[var(--muted)]">
+                Signed metadata requires both <code>SAML_SP_PRIVATE_KEY</code> and <code>SAML_SP_PUBLIC_CERT</code> environment variables.
               </p>
             </div>
           )}

--- a/src/components/apps/AppInstanceCard.tsx
+++ b/src/components/apps/AppInstanceCard.tsx
@@ -82,27 +82,26 @@ export function AppInstanceCard({ app, onDelete, onTransfer }: AppInstanceCardPr
 
   return (
     <>
-      <Card className="flex flex-col justify-between hover:shadow-md transition-shadow">
+      <Card interactive className="flex flex-col justify-between">
         <div>
-          <div className="flex items-start justify-between mb-3">
+          <div className="mb-4 flex items-start justify-between">
             <div>
-              <h3 className="font-semibold text-gray-900">{app.name}</h3>
-              <p className="text-sm text-gray-500 font-mono">/{app.slug}</p>
+              <h3 className="text-lg font-semibold tracking-tight text-[var(--text)]">{app.name}</h3>
+              <p className="font-mono text-xs text-[var(--muted)]">/{app.slug}</p>
             </div>
             <Badge variant={app.protocol.toLowerCase() as "oidc" | "saml"} />
           </div>
-          <div className="flex items-center gap-2 mb-4">
-            <div
-              className="w-4 h-4 rounded-full border border-gray-200"
+
+          <div className="mb-4 flex items-center gap-2 text-xs text-[var(--muted)]">
+            <span
+              className="h-4 w-4 rounded-full border border-[var(--border)]"
               style={{ backgroundColor: app.buttonColor || "#3B71CA" }}
             />
-            <span className="text-xs text-gray-400">
-              {new Date(app.createdAt).toLocaleDateString()}
-            </span>
+            <span>{new Date(app.createdAt).toLocaleDateString()}</span>
           </div>
         </div>
 
-        <div className="flex gap-2 pt-3 border-t border-gray-100">
+        <div className="flex gap-2 border-t border-[var(--border)] pt-4">
           <Link href={`/test/${app.slug}`} className="flex-1">
             <Button variant="primary" size="sm" className="w-full">
               Test
@@ -115,27 +114,13 @@ export function AppInstanceCard({ app, onDelete, onTransfer }: AppInstanceCardPr
           </Link>
           {canManageSourceTeam && eligibleTargetTeams.length > 0 && (
             <Button variant="ghost" size="sm" onClick={openTransferModal}>
-              <svg
-                className="w-4 h-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M7 16V4m0 0L3 8m4-4l4 4m6-4v12m0 0l-4-4m4 4l4-4"
-                />
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6-4v12m0 0l-4-4m4 4l4-4" />
               </svg>
             </Button>
           )}
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setShowDeleteModal(true)}
-          >
-            <svg className="w-4 h-4 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <Button variant="ghost" size="sm" onClick={() => setShowDeleteModal(true)}>
+            <svg className="h-4 w-4 text-[var(--danger)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
             </svg>
           </Button>
@@ -148,13 +133,13 @@ export function AppInstanceCard({ app, onDelete, onTransfer }: AppInstanceCardPr
         title="Move or Copy App"
       >
         <div className="space-y-4">
-          <p className="text-sm text-gray-600">
-            Choose a destination team where you are an admin/owner.
+          <p className="text-sm text-[var(--muted)]">
+            Choose a destination team where you are admin or owner.
           </p>
           <select
             value={targetTeamId}
             onChange={(e) => setTargetTeamId(e.target.value)}
-            className="w-full h-10 rounded-lg border border-gray-200 px-3 text-sm"
+            className="focus-ring h-11 w-full rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--text)]"
           >
             {eligibleTargetTeams.map((team) => (
               <option key={team.id} value={team.id}>
@@ -163,28 +148,20 @@ export function AppInstanceCard({ app, onDelete, onTransfer }: AppInstanceCardPr
             ))}
           </select>
 
-          {transferError && (
-            <p className="text-sm text-red-600">{transferError}</p>
-          )}
+          {transferError && <p className="text-sm text-red-500">{transferError}</p>}
 
           <div className="flex justify-end gap-2">
-            <Button
-              variant="secondary"
-              onClick={() => setShowTransferModal(false)}
-            >
+            <Button variant="secondary" onClick={() => setShowTransferModal(false)}>
               Cancel
             </Button>
             <Button
-              variant="secondary"
+              variant="subtle"
               loading={transferringMode === "COPY"}
               onClick={() => handleTransfer("COPY")}
             >
               Copy
             </Button>
-            <Button
-              loading={transferringMode === "MOVE"}
-              onClick={() => handleTransfer("MOVE")}
-            >
+            <Button loading={transferringMode === "MOVE"} onClick={() => handleTransfer("MOVE")}>
               Move
             </Button>
           </div>
@@ -196,15 +173,11 @@ export function AppInstanceCard({ app, onDelete, onTransfer }: AppInstanceCardPr
         onClose={() => setShowDeleteModal(false)}
         title="Delete App Instance"
       >
-        <p className="text-gray-600 mb-4">
-          Are you sure you want to delete <strong>{app.name}</strong>? This
-          action cannot be undone.
+        <p className="mb-4 text-sm text-[var(--muted)]">
+          Are you sure you want to delete <strong>{app.name}</strong>? This action cannot be undone.
         </p>
-        <div className="flex gap-3 justify-end">
-          <Button
-            variant="secondary"
-            onClick={() => setShowDeleteModal(false)}
-          >
+        <div className="flex justify-end gap-3">
+          <Button variant="secondary" onClick={() => setShowDeleteModal(false)}>
             Cancel
           </Button>
           <Button variant="danger" onClick={handleDelete} loading={deleting}>

--- a/src/components/apps/CreationStepper.tsx
+++ b/src/components/apps/CreationStepper.tsx
@@ -22,12 +22,10 @@ interface FormData {
   name: string;
   slug: string;
   buttonColor: string;
-  // OIDC
   issuerUrl: string;
   clientId: string;
   clientSecret: string;
   scopes: string;
-  // SAML
   entryPoint: string;
   issuer: string;
   idpCert: string;
@@ -147,49 +145,45 @@ export function CreationStepper() {
   };
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="mx-auto max-w-3xl animate-enter">
       <Stepper steps={STEPS} currentStep={step} />
 
       <Card>
-        {/* Step 0: Protocol */}
         {step === 0 && (
           <div>
-            <h2 className="text-lg font-semibold mb-4">Choose Protocol</h2>
-            <div className="grid grid-cols-2 gap-4">
+            <h2 className="mb-1 text-xl font-semibold tracking-tight text-[var(--text)]">Choose Protocol</h2>
+            <p className="mb-5 text-sm text-[var(--muted)]">Pick the identity protocol you want to test.</p>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               {(["OIDC", "SAML"] as const).map((proto) => (
                 <button
                   key={proto}
                   onClick={() => updateField("protocol", proto)}
-                  className={`p-6 rounded-lg border-2 text-left transition-all ${
+                  className={`focus-ring rounded-2xl border-2 p-5 text-left transition-colors ${
                     formData.protocol === proto
-                      ? "border-primary bg-primary/5"
-                      : "border-gray-200 hover:border-gray-300"
+                      ? "border-[var(--primary)] bg-[color-mix(in_oklab,var(--primary)_9%,transparent)]"
+                      : "border-[var(--border)] bg-[var(--surface)] hover:border-[var(--border-strong)]"
                   }`}
                 >
                   <Badge variant={proto.toLowerCase() as "oidc" | "saml"} />
-                  <h3 className="font-semibold mt-3">
-                    {proto === "OIDC"
-                      ? "OpenID Connect"
-                      : "SAML 2.0"}
+                  <h3 className="mt-3 font-semibold text-[var(--text)]">
+                    {proto === "OIDC" ? "OpenID Connect" : "SAML 2.0"}
                   </h3>
-                  <p className="text-sm text-gray-500 mt-1">
+                  <p className="mt-1 text-sm text-[var(--muted)]">
                     {proto === "OIDC"
-                      ? "OAuth 2.0-based identity protocol with JWT tokens"
-                      : "XML-based single sign-on protocol"}
+                      ? "OAuth-based identity protocol with JWT tokens"
+                      : "XML-based enterprise single sign-on protocol"}
                   </p>
                 </button>
               ))}
             </div>
-            {errors.protocol && (
-              <p className="text-sm text-red-600 mt-2">{errors.protocol}</p>
-            )}
+            {errors.protocol && <p className="mt-2 text-sm text-red-500">{errors.protocol}</p>}
           </div>
         )}
 
-        {/* Step 1: Configuration */}
         {step === 1 && formData.protocol === "OIDC" && (
           <div>
-            <h2 className="text-lg font-semibold mb-4">OIDC Configuration</h2>
+            <h2 className="mb-4 text-xl font-semibold tracking-tight text-[var(--text)]">OIDC Configuration</h2>
             <OIDCConfigFields
               values={{
                 issuerUrl: formData.issuerUrl,
@@ -204,7 +198,7 @@ export function CreationStepper() {
         )}
         {step === 1 && formData.protocol === "SAML" && (
           <div>
-            <h2 className="text-lg font-semibold mb-4">SAML Configuration</h2>
+            <h2 className="mb-4 text-xl font-semibold tracking-tight text-[var(--text)]">SAML Configuration</h2>
             <SAMLConfigFields
               values={{
                 entryPoint: formData.entryPoint,
@@ -217,10 +211,9 @@ export function CreationStepper() {
           </div>
         )}
 
-        {/* Step 2: Customize */}
         {step === 2 && (
           <div>
-            <h2 className="text-lg font-semibold mb-4">Customize</h2>
+            <h2 className="mb-4 text-xl font-semibold tracking-tight text-[var(--text)]">Customize</h2>
             <div className="space-y-4">
               <Input
                 label="App Name"
@@ -242,113 +235,71 @@ export function CreationStepper() {
                 error={errors.slug}
                 helperText={`Test URL: /test/${formData.slug || "your-slug"}`}
               />
-              <div className="space-y-1">
-                <label className="block text-sm font-medium text-gray-700">
-                  Button Color
-                </label>
+              <div className="space-y-1.5">
+                <label className="block text-sm font-medium text-[var(--text)]">Button Color</label>
                 <div className="flex items-center gap-3">
                   <input
                     type="color"
                     value={formData.buttonColor}
                     onChange={(e) => updateField("buttonColor", e.target.value)}
-                    className="w-10 h-10 rounded cursor-pointer border border-gray-300"
+                    className="h-10 w-10 cursor-pointer rounded-lg border border-[var(--border)] bg-transparent"
                   />
-                  <span className="text-sm text-gray-500 font-mono">
-                    {formData.buttonColor}
-                  </span>
+                  <span className="font-mono text-sm text-[var(--muted)]">{formData.buttonColor}</span>
                 </div>
               </div>
             </div>
           </div>
         )}
 
-        {/* Step 3: Review */}
         {step === 3 && (
           <div>
-            <h2 className="text-lg font-semibold mb-4">Review</h2>
-            <dl className="space-y-3">
-              <div className="flex justify-between py-2 border-b border-gray-100">
-                <dt className="text-sm text-gray-500">Protocol</dt>
+            <h2 className="mb-4 text-xl font-semibold tracking-tight text-[var(--text)]">Review</h2>
+            <dl className="space-y-2">
+              <div className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3">
+                <dt className="text-sm text-[var(--muted)]">Protocol</dt>
                 <dd>
                   <Badge variant={formData.protocol.toLowerCase() as "oidc" | "saml"} />
                 </dd>
               </div>
-              <div className="flex justify-between py-2 border-b border-gray-100">
-                <dt className="text-sm text-gray-500">Name</dt>
-                <dd className="text-sm font-medium">{formData.name}</dd>
+              <div className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3">
+                <dt className="text-sm text-[var(--muted)]">Name</dt>
+                <dd className="text-sm font-medium text-[var(--text)]">{formData.name}</dd>
               </div>
-              <div className="flex justify-between py-2 border-b border-gray-100">
-                <dt className="text-sm text-gray-500">Slug</dt>
-                <dd className="text-sm font-mono">{formData.slug}</dd>
+              <div className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3">
+                <dt className="text-sm text-[var(--muted)]">Slug</dt>
+                <dd className="font-mono text-sm text-[var(--text)]">/{formData.slug}</dd>
               </div>
-              {formData.protocol === "OIDC" ? (
-                <>
-                  <div className="flex justify-between py-2 border-b border-gray-100">
-                    <dt className="text-sm text-gray-500">Issuer URL</dt>
-                    <dd className="text-sm font-mono truncate ml-4 max-w-xs">
-                      {formData.issuerUrl}
-                    </dd>
-                  </div>
-                  <div className="flex justify-between py-2 border-b border-gray-100">
-                    <dt className="text-sm text-gray-500">Client ID</dt>
-                    <dd className="text-sm font-mono truncate ml-4 max-w-xs">
-                      {formData.clientId}
-                    </dd>
-                  </div>
-                  <div className="flex justify-between py-2 border-b border-gray-100">
-                    <dt className="text-sm text-gray-500">Scopes</dt>
-                    <dd className="text-sm">{formData.scopes}</dd>
-                  </div>
-                </>
-              ) : (
-                <>
-                  <div className="flex justify-between py-2 border-b border-gray-100">
-                    <dt className="text-sm text-gray-500">Entry Point</dt>
-                    <dd className="text-sm font-mono truncate ml-4 max-w-xs">
-                      {formData.entryPoint}
-                    </dd>
-                  </div>
-                  <div className="flex justify-between py-2 border-b border-gray-100">
-                    <dt className="text-sm text-gray-500">Issuer</dt>
-                    <dd className="text-sm font-mono truncate ml-4 max-w-xs">
-                      {formData.issuer}
-                    </dd>
-                  </div>
-                </>
-              )}
-              <div className="flex justify-between py-2">
-                <dt className="text-sm text-gray-500">Button Color</dt>
+              <div className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-4 py-3">
+                <dt className="text-sm text-[var(--muted)]">Button color</dt>
                 <dd className="flex items-center gap-2">
-                  <div
-                    className="w-4 h-4 rounded-full border"
+                  <span
+                    className="h-4 w-4 rounded-full border border-[var(--border)]"
                     style={{ backgroundColor: formData.buttonColor }}
                   />
-                  <span className="text-sm font-mono">
-                    {formData.buttonColor}
-                  </span>
+                  <span className="font-mono text-sm text-[var(--text)]">{formData.buttonColor}</span>
                 </dd>
               </div>
             </dl>
             {errors.submit && (
-              <p className="text-sm text-red-600 mt-4">{errors.submit}</p>
+              <p className="mt-3 text-sm text-red-500">{errors.submit}</p>
             )}
           </div>
         )}
 
-        {/* Navigation buttons */}
-        <div className="flex justify-between mt-6 pt-4 border-t border-gray-100">
+        <div className="mt-8 flex justify-between border-t border-[var(--border)] pt-5">
           <Button
             variant="secondary"
             onClick={() => setStep((s) => s - 1)}
-            disabled={step === 0}
+            disabled={step === 0 || submitting}
           >
             Back
           </Button>
+
           {step < 3 ? (
-            <Button onClick={handleNext}>Next</Button>
+            <Button onClick={handleNext}>Continue</Button>
           ) : (
             <Button onClick={handleSubmit} loading={submitting}>
-              Create App
+              Create App Instance
             </Button>
           )}
         </div>

--- a/src/components/apps/Dashboard.tsx
+++ b/src/components/apps/Dashboard.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { AppInstanceCard } from "./AppInstanceCard";
 import { TeamMembersPanel } from "./TeamMembersPanel";
 import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
 import type { RedactedAppInstance } from "@/types/app-instance";
 
 interface DashboardProps {
@@ -49,9 +50,9 @@ export function Dashboard({ initialApps, team, currentUserId }: DashboardProps) 
   };
 
   return (
-    <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_360px] gap-6 items-start">
+    <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-[minmax(0,1fr)_380px]">
       {apps.length > 0 ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           {apps.map((app) => (
             <AppInstanceCard
               key={app.id}
@@ -62,15 +63,15 @@ export function Dashboard({ initialApps, team, currentUserId }: DashboardProps) 
           ))}
         </div>
       ) : (
-        <div className="rounded-lg border border-dashed border-gray-300 bg-white p-8 text-center">
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">No Apps Yet</h2>
-          <p className="text-sm text-gray-500 mb-5">
-            This team does not have any app instances yet.
+        <Card className="border-dashed text-center" tone="subtle">
+          <h2 className="text-xl font-semibold text-[var(--text)]">No apps yet</h2>
+          <p className="mt-2 text-sm text-[var(--muted)]">
+            This team does not have any app instances.
           </p>
-          <Link href="/apps/new">
+          <Link href="/apps/new" className="mt-5 inline-block">
             <Button>Create New App</Button>
           </Link>
-        </div>
+        </Card>
       )}
       <TeamMembersPanel
         key={team.id}

--- a/src/components/apps/EditAppForm.tsx
+++ b/src/components/apps/EditAppForm.tsx
@@ -77,11 +77,9 @@ export function EditAppForm({ app }: EditAppFormProps) {
   return (
     <Card>
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="flex items-center gap-2 mb-4">
+        <div className="mb-4 flex items-center gap-2">
           <Badge variant={app.protocol.toLowerCase() as "oidc" | "saml"} />
-          <span className="text-sm text-gray-500">
-            Protocol cannot be changed
-          </span>
+          <span className="text-sm text-[var(--muted)]">Protocol cannot be changed</span>
         </div>
 
         <Input
@@ -143,24 +141,20 @@ export function EditAppForm({ app }: EditAppFormProps) {
           />
         )}
 
-        <div className="space-y-1">
-          <label className="block text-sm font-medium text-gray-700">
-            Button Color
-          </label>
+        <div className="space-y-1.5">
+          <label className="block text-sm font-medium text-[var(--text)]">Button Color</label>
           <div className="flex items-center gap-3">
             <input
               type="color"
               value={formData.buttonColor}
               onChange={(e) => updateField("buttonColor", e.target.value)}
-              className="w-10 h-10 rounded cursor-pointer border border-gray-300"
+              className="h-10 w-10 cursor-pointer rounded-lg border border-[var(--border)] bg-transparent"
             />
-            <span className="text-sm text-gray-500 font-mono">
-              {formData.buttonColor}
-            </span>
+            <span className="font-mono text-sm text-[var(--muted)]">{formData.buttonColor}</span>
           </div>
         </div>
 
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-red-500">{error}</p>}
 
         <div className="flex gap-3 pt-4">
           <Button type="submit" loading={saving}>

--- a/src/components/apps/SAMLConfigFields.tsx
+++ b/src/components/apps/SAMLConfigFields.tsx
@@ -91,22 +91,20 @@ export function SAMLConfigFields({
 
   return (
     <div className="space-y-4">
-      <div className="rounded-lg border border-gray-200 p-4 bg-gray-50/60">
-        <h3 className="text-sm font-semibold text-gray-800 mb-3">
-          Import IdP Metadata
-        </h3>
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-2)] p-4">
+        <h3 className="mb-3 text-sm font-semibold text-[var(--text)]">Import IdP Metadata</h3>
 
-        <div className="inline-flex rounded-lg border border-gray-200 mb-3 overflow-hidden">
+        <div className="mb-3 inline-flex overflow-hidden rounded-xl border border-[var(--border)]">
           <button
             type="button"
-            className={`px-3 py-1.5 text-sm ${source === "xml" ? "bg-white font-medium" : "bg-gray-100 text-gray-600"}`}
+            className={`px-3 py-1.5 text-sm ${source === "xml" ? "bg-[var(--surface)] font-medium text-[var(--text)]" : "bg-[var(--surface-2)] text-[var(--muted)]"}`}
             onClick={() => setSource("xml")}
           >
             XML
           </button>
           <button
             type="button"
-            className={`px-3 py-1.5 text-sm border-l border-gray-200 ${source === "url" ? "bg-white font-medium" : "bg-gray-100 text-gray-600"}`}
+            className={`border-l border-[var(--border)] px-3 py-1.5 text-sm ${source === "url" ? "bg-[var(--surface)] font-medium text-[var(--text)]" : "bg-[var(--surface-2)] text-[var(--muted)]"}`}
             onClick={() => setSource("url")}
           >
             URL
@@ -116,20 +114,18 @@ export function SAMLConfigFields({
         {source === "xml" && (
           <div className="space-y-2">
             <textarea
-              className="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm font-mono shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+              className="focus-ring block w-full rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm font-mono text-[var(--text)] shadow-[var(--shadow-xs)] placeholder:text-[var(--muted)]"
               rows={6}
               value={xmlInput}
               onChange={(e) => setXmlInput(e.target.value)}
               placeholder="<EntityDescriptor ...>...</EntityDescriptor>"
             />
-            <div className="flex items-center gap-3">
-              <input
-                type="file"
-                accept=".xml,text/xml,application/xml"
-                onChange={(e) => handleFileUpload(e.target.files?.[0] || null)}
-                className="text-sm text-gray-600"
-              />
-            </div>
+            <input
+              type="file"
+              accept=".xml,text/xml,application/xml"
+              onChange={(e) => handleFileUpload(e.target.files?.[0] || null)}
+              className="text-sm text-[var(--muted)]"
+            />
           </div>
         )}
 
@@ -154,44 +150,40 @@ export function SAMLConfigFields({
           </Button>
         </div>
 
-        {parseError && (
-          <p className="text-sm text-red-600 mt-3">{parseError}</p>
-        )}
+        {parseError && <p className="mt-3 text-sm text-red-500">{parseError}</p>}
 
         {parsedMetadata && (
-          <div className="mt-4 rounded-lg border border-gray-200 bg-white p-3 space-y-3">
-            <p className="text-sm font-semibold text-gray-900">
-              Parsed Metadata Preview
-            </p>
+          <div className="mt-4 space-y-3 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-3">
+            <p className="text-sm font-semibold text-[var(--text)]">Parsed Metadata Preview</p>
             <dl className="space-y-2 text-sm">
               <div>
-                <dt className="text-gray-500">IdP Entity ID</dt>
-                <dd className="font-mono break-all">
+                <dt className="text-[var(--muted)]">IdP Entity ID</dt>
+                <dd className="break-all font-mono text-[var(--text)]">
                   {parsedMetadata.idpEntityId || "Not present in metadata"}
                 </dd>
               </div>
               <div>
-                <dt className="text-gray-500">SSO Binding</dt>
-                <dd className="font-mono break-all">{parsedMetadata.binding}</dd>
+                <dt className="text-[var(--muted)]">SSO Binding</dt>
+                <dd className="break-all font-mono text-[var(--text)]">{parsedMetadata.binding}</dd>
               </div>
               <div>
-                <dt className="text-gray-500">SSO Entry Point</dt>
-                <dd className="font-mono break-all">{parsedMetadata.entryPoint}</dd>
+                <dt className="text-[var(--muted)]">SSO Entry Point</dt>
+                <dd className="break-all font-mono text-[var(--text)]">{parsedMetadata.entryPoint}</dd>
               </div>
             </dl>
 
-            <div className="rounded-md border border-gray-100 bg-gray-50 p-2">
-              <p className="text-xs text-gray-500 mb-1">Certificate (PEM)</p>
-              <pre className="text-xs text-gray-700 whitespace-pre-wrap break-all max-h-40 overflow-auto">
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--surface-2)] p-2">
+              <p className="mb-1 text-xs text-[var(--muted)]">Certificate (PEM)</p>
+              <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all text-xs text-[var(--text)]">
                 {parsedMetadata.idpCert}
               </pre>
               <CopyButton text={parsedMetadata.idpCert} className="mt-2" />
             </div>
 
             {parsedMetadata.warnings.length > 0 && (
-              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
-                <p className="text-xs font-medium text-amber-800 mb-1">Warnings</p>
-                <ul className="text-xs text-amber-800 list-disc list-inside">
+              <div className="rounded-lg border border-amber-400/50 bg-amber-100/50 px-3 py-2 text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                <p className="mb-1 text-xs font-medium">Warnings</p>
+                <ul className="list-disc space-y-0.5 pl-4 text-xs">
                   {parsedMetadata.warnings.map((warning) => (
                     <li key={warning}>{warning}</li>
                   ))}
@@ -200,7 +192,7 @@ export function SAMLConfigFields({
             )}
 
             <div className="space-y-2">
-              <label className="flex items-center gap-2 text-sm text-gray-700">
+              <label className="flex items-center gap-2 text-sm text-[var(--text)]">
                 <input
                   type="checkbox"
                   checked={applyEntryPoint}
@@ -208,7 +200,7 @@ export function SAMLConfigFields({
                 />
                 Apply SSO Entry Point URL
               </label>
-              <label className="flex items-center gap-2 text-sm text-gray-700">
+              <label className="flex items-center gap-2 text-sm text-[var(--text)]">
                 <input
                   type="checkbox"
                   checked={applyIdpCert}
@@ -218,11 +210,7 @@ export function SAMLConfigFields({
               </label>
             </div>
 
-            <Button
-              type="button"
-              variant="primary"
-              onClick={handleApplyParsedValues}
-            >
+            <Button type="button" variant="primary" onClick={handleApplyParsedValues}>
               Apply Selected Values
             </Button>
           </div>
@@ -245,24 +233,18 @@ export function SAMLConfigFields({
         error={errors.issuer}
         helperText="Your Service Provider Entity ID"
       />
-      <div className="space-y-1">
-        <label className="block text-sm font-medium text-gray-700">
-          IdP Certificate (PEM)
-        </label>
+      <div className="space-y-1.5">
+        <label className="block text-sm font-medium text-[var(--text)]">IdP Certificate (PEM)</label>
         <textarea
-          className={`block w-full rounded-lg border px-3 py-2 text-sm font-mono shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary ${
-            errors.idpCert ? "border-red-300" : "border-gray-300"
-          }`}
+          className={`focus-ring block w-full rounded-xl border bg-[var(--surface)] px-3 py-2 text-sm font-mono text-[var(--text)] shadow-[var(--shadow-xs)] placeholder:text-[var(--muted)] ${errors.idpCert ? "border-red-400" : "border-[var(--border)]"}`}
           rows={6}
           placeholder={idpCertPlaceholder}
           value={values.idpCert}
           onChange={(e) => onChange("idpCert", e.target.value)}
         />
-        {errors.idpCert && (
-          <p className="text-sm text-red-600">{errors.idpCert}</p>
-        )}
-        <p className="text-sm text-gray-500">
-          The IDP&apos;s public X.509 certificate in PEM format
+        {errors.idpCert && <p className="text-sm text-red-500">{errors.idpCert}</p>}
+        <p className="text-sm text-[var(--muted)]">
+          The IdP&apos;s public X.509 certificate in PEM format
         </p>
       </div>
     </div>

--- a/src/components/apps/TeamMembersPanel.tsx
+++ b/src/components/apps/TeamMembersPanel.tsx
@@ -131,61 +131,63 @@ export function TeamMembersPanel({
   return (
     <Card className="h-full">
       <div className="mb-4">
-        <h2 className="text-lg font-semibold text-gray-900">Team Members</h2>
-        <p className="text-sm text-gray-500 mt-1">
+        <h2 className="text-lg font-semibold text-[var(--text)]">Team Members</h2>
+        <p className="mt-1 text-sm text-[var(--muted)]">
           {isPersonal ? "Personal Workspace" : teamName} · {members.length} member
           {members.length !== 1 ? "s" : ""}
         </p>
       </div>
 
       {error && (
-        <div className="mb-3 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+        <div className="mb-3 rounded-xl border border-red-300/50 bg-red-100/40 p-3 text-sm text-red-600 dark:border-red-600/40 dark:bg-red-500/10 dark:text-red-300">
           {error}
         </div>
       )}
       {success && (
-        <div className="mb-3 rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-700">
+        <div className="mb-3 rounded-xl border border-emerald-300/50 bg-emerald-100/40 p-3 text-sm text-emerald-700 dark:border-emerald-600/40 dark:bg-emerald-500/10 dark:text-emerald-200">
           {success}
         </div>
       )}
 
-      <div className="space-y-2 mb-6 max-h-96 overflow-auto pr-1">
+      <div className="mb-6 max-h-96 space-y-2 overflow-auto pr-1">
         {members.map((member) => (
           <div
             key={member.id}
-            className="rounded-lg border border-gray-100 px-3 py-2 flex items-center justify-between gap-3"
+            className="rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2.5"
           >
-            <div className="min-w-0">
-              <div className="text-sm font-medium text-gray-900 truncate">
-                {member.user.name}
-                {member.user.id === currentUserId ? " (You)" : ""}
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium text-[var(--text)]">
+                  {member.user.name}
+                  {member.user.id === currentUserId ? " (You)" : ""}
+                </div>
+                <div className="truncate text-xs text-[var(--muted)]">{member.user.email}</div>
               </div>
-              <div className="text-xs text-gray-500 truncate">{member.user.email}</div>
-            </div>
-            <div className="flex items-center gap-2 shrink-0">
-              <Badge variant={roleBadgeVariant(member.role)}>{member.role}</Badge>
-              {canManageMembers && canRemoveMember(currentUserRole, member.role) && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  loading={removingId === member.user.id}
-                  onClick={() => handleRemoveMember(member)}
-                  className="text-red-600 hover:text-red-700"
-                >
-                  Remove
-                </Button>
-              )}
+              <div className="flex shrink-0 items-center gap-2">
+                <Badge variant={roleBadgeVariant(member.role)}>{member.role}</Badge>
+                {canManageMembers && canRemoveMember(currentUserRole, member.role) && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    loading={removingId === member.user.id}
+                    onClick={() => handleRemoveMember(member)}
+                    className="text-[var(--danger)]"
+                  >
+                    Remove
+                  </Button>
+                )}
+              </div>
             </div>
           </div>
         ))}
         {members.length === 0 && (
-          <p className="text-sm text-gray-500">No members found.</p>
+          <p className="text-sm text-[var(--muted)]">No members found.</p>
         )}
       </div>
 
       {canManageMembers && !isPersonal && (
-        <form onSubmit={handleAddOrInvite} className="space-y-3 border-t border-gray-100 pt-4">
-          <h3 className="text-sm font-semibold text-gray-900">
+        <form onSubmit={handleAddOrInvite} className="space-y-3 border-t border-[var(--border)] pt-4">
+          <h3 className="text-sm font-semibold text-[var(--text)]">
             Add Existing User or Invite by Email
           </h3>
           <Input
@@ -200,7 +202,7 @@ export function TeamMembersPanel({
             <select
               value={role}
               onChange={(e) => setRole(e.target.value as TeamRole)}
-              className="h-10 rounded-lg border border-gray-200 px-3 text-sm"
+              className="focus-ring h-10 rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--text)]"
             >
               <option value="MEMBER">Member</option>
               <option value="ADMIN">Admin</option>

--- a/src/components/inspector/ClaimsTable.tsx
+++ b/src/components/inspector/ClaimsTable.tsx
@@ -19,31 +19,27 @@ export function ClaimsTable({ claims }: ClaimsTableProps) {
   };
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto rounded-xl border border-[var(--border)]">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-gray-200">
+          <tr className="bg-[var(--surface-2)]">
             <th
-              className="text-left py-3 px-4 font-medium text-gray-500 cursor-pointer hover:text-gray-700"
+              className="cursor-pointer px-4 py-3 text-left font-semibold text-[var(--muted)] transition-colors hover:text-[var(--text)]"
               onClick={() => setSortAsc(!sortAsc)}
             >
               Claim Name {sortAsc ? "\u2191" : "\u2193"}
             </th>
-            <th className="text-left py-3 px-4 font-medium text-gray-500">
-              Value
-            </th>
+            <th className="px-4 py-3 text-left font-semibold text-[var(--muted)]">Value</th>
           </tr>
         </thead>
         <tbody>
           {entries.map(([key, value]) => (
             <tr
               key={key}
-              className="border-b border-gray-100 hover:bg-gray-50"
+              className="border-t border-[var(--border)] hover:bg-[var(--surface-2)]"
             >
-              <td className="py-3 px-4 font-mono text-primary font-medium">
-                {key}
-              </td>
-              <td className="py-3 px-4 font-mono text-gray-700 break-all whitespace-pre-wrap">
+              <td className="px-4 py-3 font-mono font-medium text-[var(--primary)]">{key}</td>
+              <td className="break-all whitespace-pre-wrap px-4 py-3 font-mono text-[var(--text)]">
                 {formatValue(value)}
               </td>
             </tr>
@@ -51,7 +47,7 @@ export function ClaimsTable({ claims }: ClaimsTableProps) {
         </tbody>
       </table>
       {entries.length === 0 && (
-        <p className="text-center text-gray-400 py-8">No claims available</p>
+        <p className="py-8 text-center text-[var(--muted)]">No claims available</p>
       )}
     </div>
   );

--- a/src/components/inspector/JWTDecoder.tsx
+++ b/src/components/inspector/JWTDecoder.tsx
@@ -8,7 +8,6 @@ interface JWTDecoderProps {
 }
 
 function base64UrlDecode(str: string): string {
-  // Replace URL-safe chars and add padding
   const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
   const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
   try {
@@ -23,7 +22,7 @@ export function JWTDecoder({ token }: JWTDecoderProps) {
 
   if (parts.length !== 3) {
     return (
-      <p className="text-gray-500 text-sm">
+      <p className="text-sm text-[var(--muted)]">
         Invalid JWT format (expected 3 parts, got {parts.length})
       </p>
     );
@@ -46,26 +45,20 @@ export function JWTDecoder({ token }: JWTDecoderProps) {
   }
 
   const sections = [
-    { title: "Header", content: header, color: "text-red-400" },
-    { title: "Payload", content: payload, color: "text-purple-400" },
-    {
-      title: "Signature",
-      content: signatureB64,
-      color: "text-blue-400",
-    },
+    { title: "Header", content: header, color: "text-rose-400" },
+    { title: "Payload", content: payload, color: "text-cyan-400" },
+    { title: "Signature", content: signatureB64, color: "text-blue-400" },
   ];
 
   return (
     <div className="space-y-4">
       {sections.map((section) => (
-        <Card key={section.title} className="bg-gray-50">
-          <div className="flex items-center justify-between mb-2">
-            <h4 className={`text-sm font-semibold ${section.color}`}>
-              {section.title}
-            </h4>
+        <Card key={section.title} tone="subtle">
+          <div className="mb-2 flex items-center justify-between">
+            <h4 className={`text-sm font-semibold ${section.color}`}>{section.title}</h4>
             <CopyButton text={section.content} />
           </div>
-          <pre className="bg-gray-900 text-gray-100 rounded p-3 overflow-x-auto text-sm font-mono leading-relaxed">
+          <pre className="overflow-x-auto rounded-xl border border-[var(--border)] bg-[var(--code-bg)] p-3 font-mono text-sm leading-relaxed text-[var(--code-text)]">
             {section.content}
           </pre>
         </Card>

--- a/src/components/inspector/RawPayloadView.tsx
+++ b/src/components/inspector/RawPayloadView.tsx
@@ -14,16 +14,16 @@ export function RawPayloadView({ data, format }: RawPayloadViewProps) {
     try {
       formatted = JSON.stringify(JSON.parse(data), null, 2);
     } catch {
-      // Already formatted or not valid JSON
+      // Already formatted or not valid JSON.
     }
   }
 
   return (
     <div>
-      <div className="flex justify-end mb-2">
+      <div className="mb-2 flex justify-end">
         <CopyButton text={formatted} />
       </div>
-      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 overflow-x-auto text-sm font-mono leading-relaxed max-h-[500px] overflow-y-auto">
+      <pre className="max-h-[540px] overflow-x-auto overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--code-bg)] p-4 font-mono text-sm leading-relaxed text-[var(--code-text)]">
         {formatted}
       </pre>
     </div>

--- a/src/components/inspector/SessionInfo.tsx
+++ b/src/components/inspector/SessionInfo.tsx
@@ -27,34 +27,25 @@ export function SessionInfo({
   };
 
   return (
-    <div className="flex flex-wrap items-center gap-4 p-4 bg-gray-50 rounded-lg">
+    <div className="flex flex-wrap items-center gap-3 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-[var(--shadow-sm)]">
       <div className="flex items-center gap-2">
-        <span className="text-sm text-gray-500">Protocol:</span>
+        <span className="text-sm text-[var(--muted)]">Protocol:</span>
         <Badge variant={protocol.toLowerCase() as "oidc" | "saml"} />
       </div>
       <div className="flex items-center gap-2">
-        <span className="text-sm text-gray-500">Slug:</span>
-        <code className="text-sm font-mono text-gray-700">{slug}</code>
+        <span className="text-sm text-[var(--muted)]">Slug:</span>
+        <code className="rounded bg-[var(--surface-2)] px-2 py-0.5 text-sm text-[var(--text)]">{slug}</code>
       </div>
       <div className="flex items-center gap-2">
-        <span className="text-sm text-gray-500">Authenticated:</span>
-        <span className="text-sm text-gray-700">
-          {new Date(authenticatedAt).toLocaleString()}
-        </span>
+        <span className="text-sm text-[var(--muted)]">Authenticated:</span>
+        <span className="text-sm text-[var(--text)]">{new Date(authenticatedAt).toLocaleString()}</span>
       </div>
       <div className="flex items-center gap-2">
-        <span className="text-sm text-gray-500">Cookie:</span>
-        <code className="text-sm font-mono text-gray-700">
-          authlab_{slug}
-        </code>
+        <span className="text-sm text-[var(--muted)]">Cookie:</span>
+        <code className="rounded bg-[var(--surface-2)] px-2 py-0.5 text-sm text-[var(--text)]">authlab_{slug}</code>
       </div>
       <div className="ml-auto">
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={handleLogout}
-          loading={loggingOut}
-        >
+        <Button variant="secondary" size="sm" onClick={handleLogout} loading={loggingOut}>
           Logout
         </Button>
       </div>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { useUser } from "@/components/providers/UserProvider";
+import { ThemeToggle } from "./ThemeToggle";
 import { TeamSwitcher } from "./TeamSwitcher";
 import { UserMenu } from "./UserMenu";
 
@@ -12,7 +13,7 @@ const navItems = [
     href: "/",
     label: "Dashboard",
     icon: (
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
       </svg>
     ),
@@ -21,7 +22,7 @@ const navItems = [
     href: "/apps/new",
     label: "Create New",
     icon: (
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
       </svg>
     ),
@@ -30,7 +31,7 @@ const navItems = [
     href: "/teams/new",
     label: "Teams",
     icon: (
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
       </svg>
     ),
@@ -46,52 +47,54 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     const user = useUser();
     isSystemAdmin = user.isSystemAdmin;
   } catch {
-    // UserProvider not available (shouldn't happen in dashboard layout)
+    // UserProvider not available in unexpected context.
   }
 
   return (
-    <div className="min-h-screen flex">
-      {/* Mobile overlay */}
+    <div className="min-h-screen lg:grid lg:grid-cols-[280px_minmax(0,1fr)]">
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          className="fixed inset-0 z-40 bg-slate-950/45 backdrop-blur-sm lg:hidden"
           onClick={() => setSidebarOpen(false)}
         />
       )}
 
-      {/* Sidebar */}
       <aside
-        className={`fixed lg:static inset-y-0 left-0 z-50 w-64 bg-white border-r border-gray-200 transform transition-transform lg:translate-x-0 flex flex-col ${
+        className={`fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col border-r border-[var(--border)] bg-[var(--surface)] shadow-[var(--shadow-sm)] transition-transform duration-300 lg:static lg:translate-x-0 ${
           sidebarOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
-        <div className="flex items-center gap-2 px-6 py-5 border-b border-gray-200">
-          <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
-            <svg className="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-            </svg>
+        <div className="border-b border-[var(--border)] px-5 py-5">
+          <div className="mb-4 flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[var(--primary)] text-white shadow-[var(--shadow-xs)]">
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+              </svg>
+            </div>
+            <div>
+              <p className="text-lg font-semibold tracking-tight text-[var(--text)]">AuthLab</p>
+              <p className="text-xs uppercase tracking-[0.12em] text-[var(--muted)]">Identity Workbench</p>
+            </div>
           </div>
-          <span className="text-lg font-bold text-gray-900">AuthLab</span>
+          <ThemeToggle />
         </div>
 
         <TeamSwitcher />
 
-        <nav className="px-3 py-2 space-y-1 flex-1">
+        <nav className="flex-1 space-y-1.5 px-3 py-2">
           {navItems.map((item) => {
             const isActive =
-              item.href === "/"
-                ? pathname === "/"
-                : pathname.startsWith(item.href);
+              item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
 
             return (
               <Link
                 key={item.href}
                 href={item.href}
                 onClick={() => setSidebarOpen(false)}
-                className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+                className={`focus-ring flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors ${
                   isActive
-                    ? "bg-primary/10 text-primary"
-                    : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                    ? "bg-[color-mix(in_oklab,var(--primary)_18%,transparent)] text-[var(--primary)]"
+                    : "text-[var(--muted)] hover:bg-[var(--surface-2)] hover:text-[var(--text)]"
                 }`}
               >
                 {item.icon}
@@ -99,17 +102,18 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               </Link>
             );
           })}
+
           {isSystemAdmin && (
             <Link
               href="/admin/settings"
               onClick={() => setSidebarOpen(false)}
-              className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+              className={`focus-ring flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors ${
                 pathname.startsWith("/admin")
-                  ? "bg-primary/10 text-primary"
-                  : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                  ? "bg-[color-mix(in_oklab,var(--primary)_18%,transparent)] text-[var(--primary)]"
+                  : "text-[var(--muted)] hover:bg-[var(--surface-2)] hover:text-[var(--text)]"
               }`}
             >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
@@ -121,22 +125,22 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <UserMenu />
       </aside>
 
-      {/* Main content */}
-      <div className="flex-1 flex flex-col min-w-0">
-        {/* Mobile header */}
-        <header className="lg:hidden flex items-center gap-4 px-4 py-3 bg-white border-b border-gray-200">
+      <div className="min-w-0">
+        <header className="sticky top-0 z-30 flex items-center justify-between border-b border-[var(--border)] bg-[color-mix(in_oklab,var(--bg)_78%,transparent)] px-4 py-3 backdrop-blur lg:hidden">
           <button
             onClick={() => setSidebarOpen(true)}
-            className="text-gray-600 hover:text-gray-900"
+            className="focus-ring rounded-lg p-1.5 text-[var(--muted)] transition-colors hover:bg-[var(--surface)] hover:text-[var(--text)]"
+            aria-label="Open navigation"
           >
-            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
             </svg>
           </button>
-          <span className="text-lg font-bold text-gray-900">AuthLab</span>
+          <p className="text-base font-semibold tracking-tight text-[var(--text)]">AuthLab</p>
+          <ThemeToggle compact />
         </header>
 
-        <main className="flex-1 p-6 lg:p-8">{children}</main>
+        <main className="p-4 lg:p-8">{children}</main>
       </div>
     </div>
   );

--- a/src/components/layout/TeamSwitcher.tsx
+++ b/src/components/layout/TeamSwitcher.tsx
@@ -37,77 +37,49 @@ export function TeamSwitcher() {
       return;
     }
 
-    // Full navigation ensures dashboard always re-renders with the new session team.
     window.location.assign("/");
   }
 
   return (
-    <div ref={ref} className="relative px-3 py-3">
+    <div ref={ref} className="relative border-b border-[var(--border)] px-3 py-3">
       <button
         onClick={() => setOpen(!open)}
-        className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors"
+        className="focus-ring flex w-full items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2 text-sm font-medium text-[var(--text)] transition-colors hover:border-[var(--border-strong)]"
       >
-        <svg
-          className="w-4 h-4 text-gray-500 shrink-0"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-          />
+        <svg className="h-4 w-4 shrink-0 text-[var(--muted)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
         </svg>
-        <span className="truncate flex-1 text-left">{displayName}</span>
-        <svg
-          className={`w-4 h-4 text-gray-400 transition-transform ${open ? "rotate-180" : ""}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M19 9l-7 7-7-7"
-          />
+        <span className="flex-1 truncate text-left">{displayName}</span>
+        <svg className={`h-4 w-4 text-[var(--muted)] transition-transform ${open ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </button>
 
       {open && (
-        <div className="absolute left-3 right-3 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1">
-          {teams.map((team) => (
-            <button
-              key={team.id}
-              onClick={() => switchTeam(team)}
-              className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 flex items-center justify-between ${
-                team.id === activeTeamId
-                  ? "text-primary font-medium"
-                  : "text-gray-700"
-              }`}
-            >
-              <span className="truncate">
-                {team.isPersonal ? "Personal" : team.name}
-              </span>
-              {team.id === activeTeamId && (
-                <svg
-                  className="w-4 h-4 text-primary shrink-0"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
-              )}
-            </button>
-          ))}
+        <div className="absolute left-3 right-3 top-full z-50 mt-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-1 shadow-[var(--shadow-md)]">
+          {teams.map((team) => {
+            const active = team.id === activeTeamId;
+            return (
+              <button
+                key={team.id}
+                onClick={() => switchTeam(team)}
+                className={`focus-ring flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors ${
+                  active
+                    ? "bg-[color-mix(in_oklab,var(--primary)_15%,transparent)] text-[var(--primary)]"
+                    : "text-[var(--text)] hover:bg-[var(--surface-2)]"
+                }`}
+              >
+                <span className="truncate">
+                  {team.isPersonal ? "Personal" : team.name}
+                </span>
+                {active && (
+                  <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useTheme, type ThemeMode } from "@/components/providers/ThemeProvider";
+
+const MODES: ThemeMode[] = ["light", "dark", "system"];
+
+function label(mode: ThemeMode) {
+  if (mode === "light") return "Light";
+  if (mode === "dark") return "Dark";
+  return "System";
+}
+
+export function ThemeToggle({ compact = false }: { compact?: boolean }) {
+  const { mode, setMode } = useTheme();
+
+  return (
+    <div
+      className={`inline-flex items-center rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-1 ${
+        compact ? "text-xs" : "text-sm"
+      }`}
+      role="radiogroup"
+      aria-label="Theme mode"
+    >
+      {MODES.map((item) => {
+        const active = mode === item;
+        return (
+          <button
+            key={item}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => setMode(item)}
+            className={`focus-ring rounded-lg px-2.5 py-1.5 font-medium transition-colors ${
+              active
+                ? "bg-[var(--surface)] text-[var(--text)] shadow-[var(--shadow-xs)]"
+                : "text-[var(--muted)] hover:text-[var(--text)]"
+            }`}
+          >
+            {label(item)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -35,50 +35,35 @@ export function UserMenu() {
   }
 
   return (
-    <div ref={ref} className="relative px-3 py-3 border-t border-gray-200">
+    <div ref={ref} className="relative border-t border-[var(--border)] px-3 py-3">
       <button
         onClick={() => setOpen(!open)}
-        className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm hover:bg-gray-100 transition-colors"
+        className="focus-ring flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm transition-colors hover:bg-[var(--surface-2)]"
       >
-        <div className="w-8 h-8 bg-primary/10 text-primary rounded-full flex items-center justify-center text-xs font-bold shrink-0">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color-mix(in_oklab,var(--primary)_16%,transparent)] text-xs font-bold text-[var(--primary)]">
           {initials}
         </div>
-        <div className="flex-1 text-left min-w-0">
-          <div className="font-medium text-gray-900 truncate">{name}</div>
-          <div className="text-xs text-gray-500 truncate">{email}</div>
+        <div className="min-w-0 flex-1 text-left">
+          <div className="truncate font-medium text-[var(--text)]">{name}</div>
+          <div className="truncate text-xs text-[var(--muted)]">{email}</div>
         </div>
       </button>
 
       {open && (
-        <div className="absolute left-3 right-3 bottom-full mb-1 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1">
-          <Link
-            href="/settings"
-            onClick={() => setOpen(false)}
-            className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
-          >
+        <div className="absolute bottom-full left-3 right-3 z-50 mb-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-1 shadow-[var(--shadow-md)]">
+          <Link href="/settings" onClick={() => setOpen(false)} className="block rounded-lg px-3 py-2 text-sm text-[var(--text)] hover:bg-[var(--surface-2)]">
             Settings
           </Link>
-          <Link
-            href="/teams/new"
-            onClick={() => setOpen(false)}
-            className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
-          >
+          <Link href="/teams/new" onClick={() => setOpen(false)} className="block rounded-lg px-3 py-2 text-sm text-[var(--text)] hover:bg-[var(--surface-2)]">
             Create Team
           </Link>
           {isSystemAdmin && (
-            <Link
-              href="/admin/settings"
-              onClick={() => setOpen(false)}
-              className="block px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
-            >
+            <Link href="/admin/settings" onClick={() => setOpen(false)} className="block rounded-lg px-3 py-2 text-sm text-[var(--text)] hover:bg-[var(--surface-2)]">
               Admin Settings
             </Link>
           )}
-          <div className="border-t border-gray-100 my-1" />
-          <button
-            onClick={handleLogout}
-            className="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50"
-          >
+          <div className="my-1 border-t border-[var(--border)]" />
+          <button onClick={handleLogout} className="focus-ring w-full rounded-lg px-3 py-2 text-left text-sm text-[var(--danger)] hover:bg-[color-mix(in_oklab,var(--danger)_10%,transparent)]">
             Sign Out
           </button>
         </div>

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+const THEME_STORAGE_KEY = "authlab-theme-mode";
+
+export type ThemeMode = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+interface ThemeContextValue {
+  mode: ThemeMode;
+  resolvedTheme: ResolvedTheme;
+  setMode: (mode: ThemeMode) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function getStoredMode(): ThemeMode {
+  if (typeof window === "undefined") return "system";
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === "light" || stored === "dark" || stored === "system") {
+    return stored;
+  }
+  return "system";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setModeState] = useState<ThemeMode>(() => getStoredMode());
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
+    getSystemTheme(),
+  );
+
+  const resolvedTheme: ResolvedTheme = mode === "system" ? systemTheme : mode;
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleSystemThemeChange = () => {
+      setSystemTheme(media.matches ? "dark" : "light");
+    };
+
+    media.addEventListener("change", handleSystemThemeChange);
+    return () => media.removeEventListener("change", handleSystemThemeChange);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(THEME_STORAGE_KEY, mode);
+    document.documentElement.dataset.theme = resolvedTheme;
+    document.documentElement.dataset.themeMode = mode;
+  }, [mode, resolvedTheme]);
+
+  const setMode = useCallback((nextMode: ThemeMode) => {
+    setModeState(nextMode);
+  }, []);
+
+  const value = useMemo(
+    () => ({ mode, resolvedTheme, setMode }),
+    [mode, resolvedTheme, setMode],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+  return context;
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -5,11 +5,16 @@ interface BadgeProps {
 }
 
 const variants = {
-  oidc: "bg-blue-100 text-blue-800",
-  saml: "bg-green-100 text-green-800",
-  blue: "bg-blue-100 text-blue-800",
-  green: "bg-green-100 text-green-800",
-  gray: "bg-gray-100 text-gray-800",
+  oidc:
+    "border border-blue-300/60 bg-blue-100/70 text-blue-900 dark:border-blue-500/40 dark:bg-blue-500/15 dark:text-blue-100",
+  saml:
+    "border border-teal-300/60 bg-teal-100/70 text-teal-900 dark:border-teal-500/40 dark:bg-teal-500/15 dark:text-teal-100",
+  blue:
+    "border border-blue-300/60 bg-blue-100/70 text-blue-900 dark:border-blue-500/40 dark:bg-blue-500/15 dark:text-blue-100",
+  green:
+    "border border-emerald-300/60 bg-emerald-100/70 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-500/15 dark:text-emerald-100",
+  gray:
+    "border border-[var(--border)] bg-[var(--surface-2)] text-[var(--muted)]",
 };
 
 const defaultLabels: Record<string, string> = {
@@ -20,7 +25,7 @@ const defaultLabels: Record<string, string> = {
 export function Badge({ variant, children, className = "" }: BadgeProps) {
   return (
     <span
-      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${variants[variant]} ${className}`}
+      className={`inline-flex h-6 items-center rounded-full px-2.5 text-[11px] font-semibold uppercase tracking-[0.08em] ${variants[variant]} ${className}`}
     >
       {children || defaultLabels[variant] || variant.toUpperCase()}
     </span>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -4,19 +4,21 @@ import { ButtonHTMLAttributes, forwardRef } from "react";
 
 const variants = {
   primary:
-    "bg-primary text-white hover:bg-primary-dark focus:ring-primary/50",
+    "border-transparent bg-[var(--primary)] text-white hover:bg-[var(--primary-strong)]",
   secondary:
-    "bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 focus:ring-gray-300/50",
-  danger:
-    "bg-red-600 text-white hover:bg-red-700 focus:ring-red-500/50",
+    "border-[var(--border)] bg-[var(--surface)] text-[var(--text)] hover:bg-[var(--surface-2)]",
   ghost:
-    "text-gray-600 hover:bg-gray-100 focus:ring-gray-300/50",
+    "border-transparent bg-transparent text-[var(--muted)] hover:bg-[var(--surface-2)] hover:text-[var(--text)]",
+  subtle:
+    "border-[var(--border)] bg-[var(--surface-2)] text-[var(--text)] hover:border-[var(--border-strong)] hover:bg-[var(--surface)]",
+  danger:
+    "border-transparent bg-[var(--danger)] text-white hover:brightness-95",
 };
 
 const sizes = {
-  sm: "px-3 py-1.5 text-sm",
-  md: "px-4 py-2 text-sm",
-  lg: "px-6 py-3 text-base",
+  sm: "h-9 px-3 text-xs",
+  md: "h-10 px-4 text-sm",
+  lg: "h-12 px-6 text-sm",
 };
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -41,28 +43,24 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button
         ref={ref}
-        className={`inline-flex items-center justify-center rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed ${variants[variant]} ${sizes[size]} ${className}`}
+        className={`focus-ring inline-flex items-center justify-center gap-2 rounded-xl border font-medium tracking-[0.01em] transition-[background-color,color,border-color,box-shadow,transform] duration-200 active:translate-y-px disabled:cursor-not-allowed disabled:opacity-60 ${variants[variant]} ${sizes[size]} ${className}`}
         disabled={disabled || loading}
         {...props}
       >
         {loading && (
-          <svg
-            className="animate-spin -ml-1 mr-2 h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
+          <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
             <circle
-              className="opacity-25"
+              className="opacity-30"
               cx="12"
               cy="12"
               r="10"
               stroke="currentColor"
-              strokeWidth="4"
+              strokeWidth="3"
             />
             <path
-              className="opacity-75"
+              className="opacity-90"
               fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              d="M4 12a8 8 0 0 1 8-8V1C5.925 1 1 5.925 1 12h3Z"
             />
           </svg>
         )}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -2,17 +2,34 @@ import { HTMLAttributes } from "react";
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {
   padding?: boolean;
+  tone?: "default" | "subtle" | "inverse";
+  interactive?: boolean;
 }
+
+const tones = {
+  default:
+    "bg-[var(--surface)] border-[var(--border)] text-[var(--text)] shadow-[var(--shadow-sm)]",
+  subtle:
+    "bg-[var(--surface-2)] border-[var(--border)] text-[var(--text)]",
+  inverse:
+    "bg-[var(--surface-inverse)] border-transparent text-[#0f2238]",
+};
 
 export function Card({
   children,
   className = "",
   padding = true,
+  tone = "default",
+  interactive = false,
   ...props
 }: CardProps) {
   return (
     <div
-      className={`bg-white rounded-lg border border-gray-200 shadow-sm ${padding ? "p-6" : ""} ${className}`}
+      className={`rounded-2xl border ${tones[tone]} ${
+        interactive
+          ? "transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-0.5 hover:border-[var(--border-strong)] hover:shadow-[var(--shadow-md)]"
+          : ""
+      } ${padding ? "p-6" : ""} ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -19,18 +19,18 @@ export function CopyButton({ text, className = "" }: CopyButtonProps) {
   return (
     <button
       onClick={handleCopy}
-      className={`inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 transition-colors ${className}`}
+      className={`focus-ring inline-flex h-8 items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-2.5 text-xs font-medium text-[var(--muted)] transition-colors hover:bg-[var(--surface-2)] hover:text-[var(--text)] ${className}`}
     >
       {copied ? (
         <>
-          <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="h-3.5 w-3.5 text-[var(--success)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
           </svg>
-          Copied!
+          Copied
         </>
       ) : (
         <>
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
           </svg>
           Copy

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -13,26 +13,26 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const inputId = id || label.toLowerCase().replace(/\s+/g, "-");
 
     return (
-      <div className="space-y-1">
+      <div className="space-y-1.5">
         <label
           htmlFor={inputId}
-          className="block text-sm font-medium text-gray-700"
+          className="block text-sm font-medium text-[var(--text)]"
         >
           {label}
         </label>
         <input
           ref={ref}
           id={inputId}
-          className={`block w-full rounded-lg border px-3 py-2 text-sm shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary ${
+          className={`focus-ring block h-11 w-full rounded-xl border bg-[var(--surface)] px-3.5 text-sm text-[var(--text)] shadow-[var(--shadow-xs)] transition-[border-color,box-shadow,background-color] placeholder:text-[var(--muted)] ${
             error
-              ? "border-red-300 focus:border-red-500 focus:ring-red-500/50"
-              : "border-gray-300"
+              ? "border-red-400"
+              : "border-[var(--border)] hover:border-[var(--border-strong)]"
           } ${className}`}
           {...props}
         />
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-red-500">{error}</p>}
         {helperText && !error && (
-          <p className="text-sm text-gray-500">{helperText}</p>
+          <p className="text-sm text-[var(--muted)]">{helperText}</p>
         )}
       </div>
     );

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -8,9 +8,24 @@ interface ModalProps {
   onClose: () => void;
   title: string;
   children: ReactNode;
+  size?: "sm" | "md" | "lg";
+  tone?: "default" | "subtle";
 }
 
-export function Modal({ isOpen, onClose, title, children }: ModalProps) {
+const sizes = {
+  sm: "max-w-md",
+  md: "max-w-lg",
+  lg: "max-w-2xl",
+};
+
+export function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  size = "md",
+  tone = "default",
+}: ModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -27,24 +42,29 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
   return createPortal(
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/55 px-4 backdrop-blur-sm"
       onClick={(e) => {
         if (e.target === overlayRef.current) onClose();
       }}
     >
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-md mx-4">
-        <div className="flex items-center justify-between px-6 py-4 border-b">
-          <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      <div
+        className={`w-full ${sizes[size]} overflow-hidden rounded-2xl border border-[var(--border)] ${
+          tone === "subtle" ? "bg-[var(--surface-2)]" : "bg-[var(--surface)]"
+        } shadow-[var(--shadow-md)] animate-enter`}
+      >
+        <div className="flex items-center justify-between border-b border-[var(--border)] px-6 py-4">
+          <h3 className="text-lg font-semibold text-[var(--text)]">{title}</h3>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
+            className="focus-ring rounded-lg p-1 text-[var(--muted)] transition-colors hover:bg-[var(--surface-2)] hover:text-[var(--text)]"
+            aria-label="Close modal"
           >
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
-        <div className="px-6 py-4">{children}</div>
+        <div className="px-6 py-5">{children}</div>
       </div>
     </div>,
     document.body,

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -11,24 +11,29 @@ interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   label: string;
   options: SelectOption[];
   error?: string;
+  helperText?: string;
 }
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  ({ label, options, error, className = "", id, ...props }, ref) => {
+  ({ label, options, error, helperText, className = "", id, ...props }, ref) => {
     const selectId = id || label.toLowerCase().replace(/\s+/g, "-");
 
     return (
-      <div className="space-y-1">
+      <div className="space-y-1.5">
         <label
           htmlFor={selectId}
-          className="block text-sm font-medium text-gray-700"
+          className="block text-sm font-medium text-[var(--text)]"
         >
           {label}
         </label>
         <select
           ref={ref}
           id={selectId}
-          className={`block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary ${className}`}
+          className={`focus-ring block h-11 w-full rounded-xl border bg-[var(--surface)] px-3.5 text-sm text-[var(--text)] shadow-[var(--shadow-xs)] transition-[border-color,box-shadow,background-color] ${
+            error
+              ? "border-red-400"
+              : "border-[var(--border)] hover:border-[var(--border-strong)]"
+          } ${className}`}
           {...props}
         >
           {options.map((opt) => (
@@ -37,7 +42,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             </option>
           ))}
         </select>
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {helperText && !error && (
+          <p className="text-sm text-[var(--muted)]">{helperText}</p>
+        )}
       </div>
     );
   },

--- a/src/components/ui/Stepper.tsx
+++ b/src/components/ui/Stepper.tsx
@@ -11,46 +11,48 @@ interface StepperProps {
 
 export function Stepper({ steps, currentStep }: StepperProps) {
   return (
-    <div className="flex items-center justify-center mb-8">
-      {steps.map((step, index) => (
-        <div key={step.label} className="flex items-center">
-          <div className="flex flex-col items-center">
-            <div
-              className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors ${
-                index < currentStep
-                  ? "bg-primary text-white"
-                  : index === currentStep
-                    ? "bg-primary text-white ring-4 ring-primary/20"
-                    : "bg-gray-200 text-gray-600"
-              }`}
-            >
-              {index < currentStep ? (
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
-              ) : (
-                index + 1
+    <div className="mb-8 overflow-x-auto pb-2">
+      <div className="mx-auto flex min-w-max items-center gap-2 rounded-2xl border border-[var(--border)] bg-[var(--surface)] px-3 py-3 shadow-[var(--shadow-sm)]">
+        {steps.map((step, index) => {
+          const complete = index < currentStep;
+          const active = index === currentStep;
+          return (
+            <div key={step.label} className="flex items-center">
+              <div className="flex flex-col items-center">
+                <div
+                  className={`flex h-9 w-9 items-center justify-center rounded-full text-xs font-semibold transition-colors ${
+                    complete || active
+                      ? "bg-[var(--primary)] text-white"
+                      : "bg-[var(--surface-2)] text-[var(--muted)]"
+                  } ${active ? "ring-4 ring-[var(--ring)]" : ""}`}
+                >
+                  {complete ? (
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  ) : (
+                    index + 1
+                  )}
+                </div>
+                <span
+                  className={`mt-2 text-[11px] font-medium uppercase tracking-[0.08em] ${
+                    complete || active ? "text-[var(--text)]" : "text-[var(--muted)]"
+                  }`}
+                >
+                  {step.label}
+                </span>
+              </div>
+              {index < steps.length - 1 && (
+                <div
+                  className={`mx-2 mb-6 h-0.5 w-10 rounded ${
+                    complete ? "bg-[var(--primary)]" : "bg-[var(--border)]"
+                  }`}
+                />
               )}
             </div>
-            <span
-              className={`mt-1 text-xs ${
-                index <= currentStep
-                  ? "text-primary font-medium"
-                  : "text-gray-500"
-              }`}
-            >
-              {step.label}
-            </span>
-          </div>
-          {index < steps.length - 1 && (
-            <div
-              className={`w-16 h-0.5 mx-2 mt-[-1rem] ${
-                index < currentStep ? "bg-primary" : "bg-gray-200"
-              }`}
-            />
-          )}
-        </div>
-      ))}
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/components/ui/Tabs.tsx
+++ b/src/components/ui/Tabs.tsx
@@ -9,31 +9,39 @@ interface Tab {
 
 interface TabsProps {
   tabs: Tab[];
+  appearance?: "line" | "pill";
 }
 
-export function Tabs({ tabs }: TabsProps) {
+export function Tabs({ tabs, appearance = "line" }: TabsProps) {
   const [activeIndex, setActiveIndex] = useState(0);
 
   return (
-    <div>
-      <div className="border-b border-gray-200">
-        <nav className="flex -mb-px space-x-6">
-          {tabs.map((tab, index) => (
-            <button
-              key={tab.label}
-              onClick={() => setActiveIndex(index)}
-              className={`py-3 px-1 text-sm font-medium border-b-2 transition-colors ${
-                activeIndex === index
-                  ? "border-primary text-primary"
-                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-[var(--shadow-sm)]">
+      <div className="mb-4 border-b border-[var(--border)]">
+        <nav className="flex flex-wrap gap-2 pb-2">
+          {tabs.map((tab, index) => {
+            const active = activeIndex === index;
+            return (
+              <button
+                key={tab.label}
+                onClick={() => setActiveIndex(index)}
+                className={`focus-ring rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  appearance === "pill"
+                    ? active
+                      ? "bg-[var(--surface-2)] text-[var(--text)]"
+                      : "text-[var(--muted)] hover:bg-[var(--surface-2)] hover:text-[var(--text)]"
+                    : active
+                      ? "border-b-2 border-[var(--primary)] text-[var(--primary)]"
+                      : "text-[var(--muted)] hover:text-[var(--text)]"
+                }`}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
         </nav>
       </div>
-      <div className="pt-4">{tabs[activeIndex]?.content}</div>
+      <div className="animate-enter">{tabs[activeIndex]?.content}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement a full modern enterprise UI refresh across dashboard, auth, settings, teams, test, invite, and inspector surfaces
- add a token-driven theming system with light, dark, and system modes persisted in localStorage key authlab-theme-mode
- add reusable theme controls and redesign shared primitives (button/card/input/select/modal/tabs/stepper/badge/copy) for consistent dark-mode behavior

## Validation
- npm run lint
- npm run build *(sandbox limitation: Turbopack failed in this environment due port binding permissions)*

## Notes
- no backend/API behavior changes; this is a UI/UX-focused refactor
