### PR TITLE
fix(ci): correct Turso token auth in deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Apply Turso migrations
         run: |
           export PATH="$HOME/.turso:$PATH"
-          turso auth login --token "$TURSO_API_TOKEN"
           chmod +x ./scripts/ci/apply-turso-migrations.sh
           ./scripts/ci/apply-turso-migrations.sh
 


### PR DESCRIPTION
## Summary
- remove unsupported `turso auth login --token` usage in Actions
- rely on existing `TURSO_API_TOKEN` env for non-interactive Turso CLI auth

## Why
Deploy Production run failed at Turso migration step with unknown flag error.
