### PR TITLE
feat(oidc): support app-specific callback URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A developer tool for dynamically creating, saving, and launching isolated OIDC o
 - **Dynamic Provider Registry** — Create multiple OIDC or SAML app instances, each with its own slug-based URL
 - **Isolated Sessions** — Each tenant gets its own encrypted cookie (`authlab_{slug}`), so you can test multiple providers simultaneously
 - **Inspector Page** — Decoded claims table, raw JSON/XML view with copy, JWT header/payload/signature breakdown (OIDC)
-- **Global Callback Routing** — One callback URL per protocol; state/RelayState maps back to the correct tenant
+- **Callback Routing** — App-specific OIDC callback URL and global SAML callback URL; state/RelayState maps back to the correct tenant
 - **Encryption at Rest** — Client secrets and IdP certificates encrypted with AES-256-GCM in the database
 - **Secret Redaction** — API never exposes actual secrets; returns `hasClientSecret: boolean` instead
 - **Team-Centric Dashboard** — Team switcher updates apps and shows live team membership/actions in the dashboard sidebar
@@ -111,8 +111,11 @@ Visit [http://localhost:3000](http://localhost:3000). You should see the AuthLab
 
 Register these callback URLs in your identity provider's configuration:
 
-- **OIDC**: `http://localhost:3000/api/auth/callback/oidc`
-- **SAML**: `http://localhost:3000/api/auth/callback/saml`
+- **OIDC (per app)**: `http://localhost:3000/api/auth/callback/oidc/{slug}`
+- **SAML (global)**: `http://localhost:3000/api/auth/callback/saml`
+
+For OIDC, use the exact slug for the app instance you are testing (shown on each app test page).  
+Legacy OIDC callback `http://localhost:3000/api/auth/callback/oidc` remains supported for compatibility.
 
 ### 8. SAML metadata export (Service Provider metadata)
 

--- a/src/app/api/auth/callback/oidc/[slug]/route.ts
+++ b/src/app/api/auth/callback/oidc/[slug]/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { getAppInstanceBySlug } from "@/repositories/app-instance.repo";
+import { OIDCHandler } from "@/lib/oidc-handler";
+import { getState } from "@/lib/state-store";
+import { getAppSession } from "@/lib/session";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug: expectedSlug } = await params;
+  const url = new URL(request.url);
+  const state = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+
+  if (error) {
+    const errorDescription =
+      url.searchParams.get("error_description") || "Unknown error";
+    return NextResponse.json(
+      { error, description: errorDescription },
+      { status: 400 },
+    );
+  }
+
+  if (!state) {
+    return NextResponse.json(
+      { error: "Missing state parameter" },
+      { status: 400 },
+    );
+  }
+
+  // Look up state to find slug and code verifier
+  const stateEntry = getState(state);
+  if (!stateEntry) {
+    return NextResponse.json(
+      { error: "Invalid or expired state parameter" },
+      { status: 400 },
+    );
+  }
+
+  const { slug, codeVerifier } = stateEntry;
+  if (slug !== expectedSlug) {
+    return NextResponse.json(
+      { error: "Callback slug does not match login session" },
+      { status: 400 },
+    );
+  }
+  if (!codeVerifier) {
+    return NextResponse.json(
+      { error: "Missing code verifier for OIDC flow" },
+      { status: 400 },
+    );
+  }
+
+  // Load app instance
+  const appInstance = await getAppInstanceBySlug(slug);
+  if (!appInstance) {
+    return NextResponse.json(
+      { error: "App instance not found" },
+      { status: 404 },
+    );
+  }
+
+  // Process the callback
+  const handler = new OIDCHandler(appInstance);
+  const result = await handler.handleCallback(url, codeVerifier, state);
+
+  // Store in session
+  const session = await getAppSession(slug);
+  session.appSlug = slug;
+  session.protocol = "OIDC";
+  session.claims = result.claims;
+  session.rawToken = result.rawToken;
+  session.idToken = result.idToken;
+  session.accessToken = result.accessToken;
+  session.authenticatedAt = new Date().toISOString();
+  await session.save();
+
+  return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`);
+}

--- a/src/app/test/[slug]/login/route.ts
+++ b/src/app/test/[slug]/login/route.ts
@@ -23,7 +23,7 @@ export async function GET(
 
   const callbackUrl =
     appInstance.protocol === "OIDC"
-      ? `${APP_URL}/api/auth/callback/oidc`
+      ? `${APP_URL}/api/auth/callback/oidc/${slug}`
       : `${APP_URL}/api/auth/callback/saml`;
 
   const result = await handler.getAuthorizationUrl(callbackUrl);

--- a/src/app/test/[slug]/page.tsx
+++ b/src/app/test/[slug]/page.tsx
@@ -20,7 +20,10 @@ export default async function TestPage({
 
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
   const callbackType = app.protocol === "OIDC" ? "oidc" : "saml";
-  const callbackUrl = `${appUrl}/api/auth/callback/${callbackType}`;
+  const callbackUrl =
+    app.protocol === "OIDC"
+      ? `${appUrl}/api/auth/callback/${callbackType}/${app.slug}`
+      : `${appUrl}/api/auth/callback/${callbackType}`;
   const unsignedMetadataUrl =
     app.protocol === "SAML" ? `${appUrl}/api/saml/metadata/${slug}` : null;
   const signedMetadataUrl =


### PR DESCRIPTION
## Summary
- switch OIDC login redirect_uri to app-specific callback path `/api/auth/callback/oidc/{slug}`
- add dynamic OIDC callback route at `/api/auth/callback/oidc/[slug]`
- enforce callback slug/state slug match before token exchange
- update test page callback display and README callback docs

## Validation
- npm run lint