### PR TITLE
feat(auth): per-app SAML callbacks and orphaned workspace cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - OIDC flow in `src/lib/oidc-handler.ts` — issuer discovery, PKCE, authorization code grant, token extraction
 - SAML flow in `src/lib/saml-handler.ts` — SP configuration, assertion validation, attribute extraction
 - Auth factory in `src/lib/auth-factory.ts` — handler interface, protocol routing
-- Callback routes in `src/app/api/auth/callback/` — state lookup, token exchange, session persistence
+- Callback routes in `src/app/api/auth/callback/` — per-app OIDC callback (`oidc/[slug]`) + per-app SAML callback (`saml/[slug]`)
 - Login initiation in `src/app/test/[slug]/login/route.ts` — dynamic redirect construction
 
 **Key Libraries**:
@@ -40,9 +40,9 @@
 
 **Testing Protocol**:
 1. Configure a test OIDC provider (Google, Auth0 dev tenant) via the stepper UI
-2. Register `{NEXT_PUBLIC_APP_URL}/api/auth/callback/oidc` as redirect URI in the IdP
+2. Register `{NEXT_PUBLIC_APP_URL}/api/auth/callback/oidc/{slug}` as redirect URI in the IdP for that app
 3. Click "Login with OIDC" on the test page — should redirect to IdP and back to inspector
-4. For SAML, use an IdP like Okta with `{NEXT_PUBLIC_APP_URL}/api/auth/callback/saml` as ACS URL
+4. For SAML, use an IdP like Okta with `{NEXT_PUBLIC_APP_URL}/api/auth/callback/saml/{slug}` as ACS URL
 
 ### UI/Frontend Developer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ src/
 ├── app/                      # Next.js App Router pages and routes
 │   ├── api/apps/             # CRUD REST API for app instances
 │   │   └── [id]/transfer/    # Cross-team app move/copy endpoint
-│   ├── api/auth/callback/    # Global OIDC + SAML callback handlers
+│   ├── api/auth/callback/    # OIDC + SAML per-app callbacks (`oidc/[slug]`, `saml/[slug]`)
 │   ├── api/auth/logout/      # Session destruction
 │   ├── api/teams/[id]/       # Team detail, delete, leave, members, invites
 │   ├── apps/new/             # Creation stepper UI
@@ -83,7 +83,7 @@ src/
 
 1. **Auth Factory Pattern**: `createAuthHandler(appInstance)` returns an `OIDCHandler` or `SAMLHandler` based on the protocol field. Both conform to the same `AuthHandler` interface.
 
-2. **Global Callback Routing**: One callback URL per protocol registered with IdPs. The `state` parameter (OIDC) or `RelayState` (SAML) maps back to the tenant slug via an in-memory store.
+2. **Callback Routing**: OIDC and SAML both use app-specific callback URLs (`/api/auth/callback/oidc/{slug}` and `/api/auth/callback/saml/{slug}`). The `state` parameter (OIDC) or `RelayState` (SAML) maps back to the tenant slug via an in-memory store.
 
 3. **Session Isolation**: Each tenant gets its own encrypted cookie (`authlab_{slug}`), preventing cross-contamination when testing multiple providers simultaneously.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A developer tool for dynamically creating, saving, and launching isolated OIDC o
 - **Dynamic Provider Registry** — Create multiple OIDC or SAML app instances, each with its own slug-based URL
 - **Isolated Sessions** — Each tenant gets its own encrypted cookie (`authlab_{slug}`), so you can test multiple providers simultaneously
 - **Inspector Page** — Decoded claims table, raw JSON/XML view with copy, JWT header/payload/signature breakdown (OIDC)
-- **Callback Routing** — App-specific OIDC callback URL and global SAML callback URL; state/RelayState maps back to the correct tenant
+- **Callback Routing** — App-specific callback URL for both OIDC and SAML; state/RelayState maps back to the correct tenant
 - **Encryption at Rest** — Client secrets and IdP certificates encrypted with AES-256-GCM in the database
 - **Secret Redaction** — API never exposes actual secrets; returns `hasClientSecret: boolean` instead
 - **Team-Centric Dashboard** — Team switcher updates apps and shows live team membership/actions in the dashboard sidebar
@@ -112,10 +112,11 @@ Visit [http://localhost:3000](http://localhost:3000). You should see the AuthLab
 Register these callback URLs in your identity provider's configuration:
 
 - **OIDC (per app)**: `http://localhost:3000/api/auth/callback/oidc/{slug}`
-- **SAML (global)**: `http://localhost:3000/api/auth/callback/saml`
+- **SAML (per app)**: `http://localhost:3000/api/auth/callback/saml/{slug}`
 
-For OIDC, use the exact slug for the app instance you are testing (shown on each app test page).  
-Legacy OIDC callback `http://localhost:3000/api/auth/callback/oidc` remains supported for compatibility.
+Use the exact slug for the app instance you are testing (shown on each app test page).  
+OIDC example for slug `finance-oidc`: `http://localhost:3000/api/auth/callback/oidc/finance-oidc`  
+SAML example for slug `hr-saml`: `http://localhost:3000/api/auth/callback/saml/hr-saml`  
 
 ### 8. SAML metadata export (Service Provider metadata)
 

--- a/prisma/turso-migrations/20260305_cleanup_orphaned_personal_workspaces.sql
+++ b/prisma/turso-migrations/20260305_cleanup_orphaned_personal_workspaces.sql
@@ -1,0 +1,15 @@
+-- Remove orphaned personal workspaces left behind by historical user deletions.
+-- A valid personal workspace should always have an OWNER membership.
+
+BEGIN;
+
+DELETE FROM "Team"
+WHERE "isPersonal" = 1
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "TeamMember"
+    WHERE "TeamMember"."teamId" = "Team"."id"
+      AND "TeamMember"."role" = 'OWNER'
+  );
+
+COMMIT;

--- a/src/app/api/auth/callback/saml/[slug]/route.ts
+++ b/src/app/api/auth/callback/saml/[slug]/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { getAppInstanceBySlug } from "@/repositories/app-instance.repo";
+import { SAMLHandler } from "@/lib/saml-handler";
+import { getState } from "@/lib/state-store";
+import { getAppSession } from "@/lib/session";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug: expectedSlug } = await params;
+  const formData = await request.formData();
+  const samlResponse = formData.get("SAMLResponse") as string;
+  const relayState = formData.get("RelayState") as string;
+
+  if (!samlResponse) {
+    return NextResponse.json(
+      { error: "Missing SAMLResponse" },
+      { status: 400 },
+    );
+  }
+
+  if (!relayState) {
+    return NextResponse.json(
+      { error: "Missing RelayState" },
+      { status: 400 },
+    );
+  }
+
+  // Look up RelayState to find slug
+  const stateEntry = getState(relayState);
+  if (!stateEntry) {
+    return NextResponse.json(
+      { error: "Invalid or expired RelayState" },
+      { status: 400 },
+    );
+  }
+
+  const { slug } = stateEntry;
+  if (slug !== expectedSlug) {
+    return NextResponse.json(
+      { error: "Callback slug does not match login session" },
+      { status: 400 },
+    );
+  }
+
+  // Load app instance
+  const appInstance = await getAppInstanceBySlug(slug);
+  if (!appInstance) {
+    return NextResponse.json(
+      { error: "App instance not found" },
+      { status: 404 },
+    );
+  }
+
+  const callbackUrl = `${APP_URL}/api/auth/callback/saml/${slug}`;
+
+  // Process the callback
+  const handler = new SAMLHandler(appInstance);
+  const result = await handler.handleCallback(samlResponse, callbackUrl);
+
+  // Store in session
+  const session = await getAppSession(slug);
+  session.appSlug = slug;
+  session.protocol = "SAML";
+  session.claims = result.claims;
+  session.rawXml = result.rawXml;
+  session.authenticatedAt = new Date().toISOString();
+  await session.save();
+
+  return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`);
+}

--- a/src/app/api/saml/metadata/[slug]/route.ts
+++ b/src/app/api/saml/metadata/[slug]/route.ts
@@ -26,7 +26,7 @@ export async function GET(
 
   const signed = new URL(request.url).searchParams.get("signed") === "true";
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-  const callbackUrl = `${appUrl}/api/auth/callback/saml`;
+  const callbackUrl = `${appUrl}/api/auth/callback/saml/${slug}`;
 
   try {
     const metadata = signed

--- a/src/app/test/[slug]/login/route.ts
+++ b/src/app/test/[slug]/login/route.ts
@@ -24,7 +24,7 @@ export async function GET(
   const callbackUrl =
     appInstance.protocol === "OIDC"
       ? `${APP_URL}/api/auth/callback/oidc/${slug}`
-      : `${APP_URL}/api/auth/callback/saml`;
+      : `${APP_URL}/api/auth/callback/saml/${slug}`;
 
   const result = await handler.getAuthorizationUrl(callbackUrl);
 

--- a/src/app/test/[slug]/page.tsx
+++ b/src/app/test/[slug]/page.tsx
@@ -20,10 +20,7 @@ export default async function TestPage({
 
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
   const callbackType = app.protocol === "OIDC" ? "oidc" : "saml";
-  const callbackUrl =
-    app.protocol === "OIDC"
-      ? `${appUrl}/api/auth/callback/${callbackType}/${app.slug}`
-      : `${appUrl}/api/auth/callback/${callbackType}`;
+  const callbackUrl = `${appUrl}/api/auth/callback/${callbackType}/${app.slug}`;
   const unsignedMetadataUrl =
     app.protocol === "SAML" ? `${appUrl}/api/saml/metadata/${slug}` : null;
   const signedMetadataUrl =

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -47,7 +47,7 @@ export async function middleware(request: NextRequest) {
     ["POST", "PUT", "DELETE"].includes(request.method)
   ) {
     // Allow SAML callback (IdP POST) and form submissions
-    const isSamlCallback = pathname === "/api/auth/callback/saml";
+    const isSamlCallback = pathname.startsWith("/api/auth/callback/saml");
     if (!isSamlCallback) {
       const contentType = request.headers.get("content-type") || "";
       const origin = request.headers.get("origin");


### PR DESCRIPTION
## Summary
- switch SAML auth flow to app-specific callback URLs (`/api/auth/callback/saml/{slug}`)
- add slug-based SAML callback route and validate callback slug against RelayState-mapped slug
- update SAML SP metadata to emit per-app ACS callback URL
- update middleware SAML callback CSRF bypass to support slugged callback paths
- align README/AGENTS/CLAUDE docs with per-app callback routing
- add Turso one-time migration to remove orphaned personal workspaces without an OWNER member

## Validation
- npm run lint