### PR TITLE
Improve email-provider test diagnostics and fallback UX

### DIFF
--- a/src/app/(dashboard)/admin/settings/page.tsx
+++ b/src/app/(dashboard)/admin/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
@@ -79,6 +79,20 @@ export default function AdminSettingsPage() {
   const [savingProvider, setSavingProvider] = useState(false);
   const [testingProvider, setTestingProvider] = useState(false);
 
+  const applyProviderConfig = useCallback((config: ProviderConfigResponse) => {
+    setProvider(config.activeProvider || "SMTP");
+    setSmtpHost(config.smtp.host || "");
+    setSmtpPort(String(config.smtp.port || 587));
+    setSmtpSecure(Boolean(config.smtp.secure));
+    setSmtpUsername(config.smtp.username || "");
+    setSmtpFromName(config.smtp.fromName || "");
+    setSmtpFromEmail(config.smtp.fromEmail || "");
+    setSmtpHasPassword(config.smtp.hasPassword);
+    setBrevoFromName(config.brevo.fromName || "");
+    setBrevoFromEmail(config.brevo.fromEmail || "");
+    setBrevoHasApiKey(config.brevo.hasApiKey);
+  }, []);
+
   useEffect(() => {
     async function load() {
       setLoading(true);
@@ -107,19 +121,7 @@ export default function AdminSettingsPage() {
         setTeams(teamsData.teams || []);
 
         if (providerRes.ok) {
-          const config = providerData as ProviderConfigResponse;
-          setProvider(config.activeProvider || "SMTP");
-          setSmtpHost(config.smtp.host || "");
-          setSmtpPort(String(config.smtp.port || 587));
-          setSmtpSecure(Boolean(config.smtp.secure));
-          setSmtpUsername(config.smtp.username || "");
-          setSmtpFromName(config.smtp.fromName || "");
-          setSmtpFromEmail(config.smtp.fromEmail || "");
-          setSmtpHasPassword(config.smtp.hasPassword);
-
-          setBrevoFromName(config.brevo.fromName || "");
-          setBrevoFromEmail(config.brevo.fromEmail || "");
-          setBrevoHasApiKey(config.brevo.hasApiKey);
+          applyProviderConfig(providerData as ProviderConfigResponse);
         }
       } catch {
         setError("An unexpected error occurred while loading admin settings");
@@ -129,7 +131,7 @@ export default function AdminSettingsPage() {
     }
 
     load();
-  }, []);
+  }, [applyProviderConfig]);
 
   async function toggleSetting(key: string, current: string) {
     const newValue = current === "true" ? "false" : "true";
@@ -192,10 +194,15 @@ export default function AdminSettingsPage() {
         return;
       }
 
-      if (smtpPassword) setSmtpPassword("");
-      if (brevoApiKey) setBrevoApiKey("");
-      setSmtpHasPassword(true);
-      setBrevoHasApiKey(true);
+      setSmtpPassword("");
+      setBrevoApiKey("");
+
+      const providerRes = await fetch("/api/admin/email-provider");
+      const providerData = await providerRes.json();
+      if (providerRes.ok) {
+        applyProviderConfig(providerData as ProviderConfigResponse);
+      }
+
       setSuccess("Email provider settings saved");
     } catch {
       setError("An unexpected error occurred while saving provider settings");
@@ -208,12 +215,31 @@ export default function AdminSettingsPage() {
     setTestingProvider(true);
     setError("");
     setSuccess("");
+    const normalizedRecipient = testRecipient.trim();
+
+    if (!normalizedRecipient) {
+      setError("Test recipient email is required");
+      setTestingProvider(false);
+      return;
+    }
+
+    if (provider === "SMTP" && !smtpPassword && !smtpHasPassword) {
+      setError("SMTP password is required for test. Save it first or enter it now.");
+      setTestingProvider(false);
+      return;
+    }
+
+    if (provider === "BREVO" && !brevoApiKey.trim() && !brevoHasApiKey) {
+      setError("Brevo API key is required for test. Save it first or enter it now.");
+      setTestingProvider(false);
+      return;
+    }
 
     const payload =
       provider === "SMTP"
         ? {
             provider: "SMTP",
-            recipientEmail: testRecipient,
+            recipientEmail: normalizedRecipient,
             smtp: {
               host: smtpHost,
               port: Number(smtpPort),
@@ -226,9 +252,9 @@ export default function AdminSettingsPage() {
           }
         : {
             provider: "BREVO",
-            recipientEmail: testRecipient,
+            recipientEmail: normalizedRecipient,
             brevo: {
-              apiKey: brevoApiKey,
+              apiKey: brevoApiKey.trim(),
               fromName: brevoFromName,
               fromEmail: brevoFromEmail,
             },
@@ -298,7 +324,13 @@ export default function AdminSettingsPage() {
         </div>
 
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          <Input label="Test Recipient Email" type="email" value={testRecipient} onChange={(e) => setTestRecipient(e.target.value)} />
+          <Input
+            label="Test Recipient Email"
+            type="email"
+            value={testRecipient}
+            onChange={(e) => setTestRecipient(e.target.value)}
+            required
+          />
         </div>
 
         {provider === "SMTP" ? (

--- a/src/app/api/admin/email-provider/route.ts
+++ b/src/app/api/admin/email-provider/route.ts
@@ -25,8 +25,12 @@ export async function PUT(request: Request) {
   const body = await request.json();
   const parsed = UpdateEmailProviderSchema.safeParse(body);
   if (!parsed.success) {
+    const firstIssue = parsed.error.issues[0]?.message;
     return NextResponse.json(
-      { error: "Validation failed", issues: parsed.error.issues },
+      {
+        error: firstIssue ? `Validation failed: ${firstIssue}` : "Validation failed",
+        issues: parsed.error.issues,
+      },
       { status: 400 },
     );
   }

--- a/src/app/api/admin/email-provider/test/route.ts
+++ b/src/app/api/admin/email-provider/test/route.ts
@@ -16,8 +16,12 @@ export async function POST(request: Request) {
   const body = await request.json();
   const parsed = TestEmailProviderSchema.safeParse(body);
   if (!parsed.success) {
+    const firstIssue = parsed.error.issues[0]?.message;
     return NextResponse.json(
-      { error: "Validation failed", issues: parsed.error.issues },
+      {
+        error: firstIssue ? `Validation failed: ${firstIssue}` : "Validation failed",
+        issues: parsed.error.issues,
+      },
       { status: 400 },
     );
   }
@@ -54,7 +58,10 @@ export async function POST(request: Request) {
       const brevoApiKey = await resolveBrevoApiKeyForTest(parsed.data.brevo?.apiKey);
       if (!parsed.data.brevo || !brevoApiKey) {
         return NextResponse.json(
-          { error: "Brevo API key is required for test" },
+          {
+            error:
+              "Brevo API key is required for test. Enter one now or save provider settings with an API key first.",
+          },
           { status: 400 },
         );
       }
@@ -74,9 +81,13 @@ export async function POST(request: Request) {
         },
       });
     }
-  } catch {
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message.trim()
+        ? error.message
+        : "Failed to send test email";
     return NextResponse.json(
-      { error: "Failed to send test email" },
+      { error: message },
       { status: 400 },
     );
   }

--- a/src/lib/email-provider.ts
+++ b/src/lib/email-provider.ts
@@ -156,13 +156,15 @@ export async function saveEmailProviderConfig(input: EmailProviderConfigInput) {
   }
 
   if (input.brevo) {
+    const normalizedBrevoApiKey = input.brevo.apiKey?.trim();
+
     await Promise.all([
       setSetting(KEYS.brevoFromName, input.brevo.fromName),
       setSetting(KEYS.brevoFromEmail, input.brevo.fromEmail),
     ]);
 
-    if (input.brevo.apiKey) {
-      await setSetting(KEYS.brevoApiKeyEnc, encrypt(input.brevo.apiKey));
+    if (normalizedBrevoApiKey) {
+      await setSetting(KEYS.brevoApiKeyEnc, encrypt(normalizedBrevoApiKey));
     }
   }
 }
@@ -188,11 +190,16 @@ async function sendWithSmtp(config: Required<SmtpConfigInput>, email: SendEmailI
 }
 
 async function sendWithBrevo(config: Required<BrevoConfigInput>, email: SendEmailInput) {
+  const apiKey = config.apiKey.trim();
+  if (!apiKey) {
+    throw new Error("Brevo API key is required");
+  }
+
   const res = await fetch("https://api.brevo.com/v3/smtp/email", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "api-key": config.apiKey,
+      "api-key": apiKey,
     },
     body: JSON.stringify({
       sender: {
@@ -207,7 +214,26 @@ async function sendWithBrevo(config: Required<BrevoConfigInput>, email: SendEmai
   });
 
   if (!res.ok) {
-    throw new Error("Brevo API send failed");
+    const bodyText = await res.text();
+    let reason = `HTTP ${res.status}`;
+    if (bodyText) {
+      try {
+        const parsed = JSON.parse(bodyText) as {
+          message?: unknown;
+          code?: unknown;
+        };
+        if (typeof parsed.message === "string" && parsed.message.trim()) {
+          reason = parsed.message.trim();
+        } else if (typeof parsed.code === "string" && parsed.code.trim()) {
+          reason = parsed.code.trim();
+        }
+      } catch {
+        reason = bodyText.trim();
+      }
+    }
+
+    const normalizedReason = reason.replace(/\s+/g, " ").slice(0, 240);
+    throw new Error(`Brevo send failed (${res.status}): ${normalizedReason}`);
   }
 }
 
@@ -245,8 +271,9 @@ export async function resolveSmtpPasswordForTest(
 export async function resolveBrevoApiKeyForTest(
   providedApiKey?: string,
 ): Promise<string | null> {
-  if (providedApiKey && providedApiKey.trim().length > 0) {
-    return providedApiKey;
+  const normalizedProvided = providedApiKey?.trim();
+  if (normalizedProvided) {
+    return normalizedProvided;
   }
 
   const apiKeyEnc = await getRequiredSetting(KEYS.brevoApiKeyEnc);
@@ -254,7 +281,8 @@ export async function resolveBrevoApiKeyForTest(
     return null;
   }
 
-  return decrypt(apiKeyEnc);
+  const decrypted = decrypt(apiKeyEnc).trim();
+  return decrypted || null;
 }
 
 async function loadActiveProviderConfig(): Promise<


### PR DESCRIPTION
## Summary
- improve admin settings UI state handling after save by reloading masked provider config
- add client-side validation for test recipient and missing write-only secrets before request
- improve API validation errors to include the first actionable issue
- normalize/trim Brevo API keys and return clearer Brevo transport error details

## Why
- users were seeing generic 400 responses while testing provider config
- UI could show a stale/misleading has-secret state after save
- troubleshooting failed test-email sends needed concrete API error feedback

## Validation
- npm run lint
- npx tsc --noEmit