### PR TITLE
Fix Brevo test validation when write-only API key is blank

### DIFF
--- a/src/app/(dashboard)/admin/settings/page.tsx
+++ b/src/app/(dashboard)/admin/settings/page.tsx
@@ -245,7 +245,7 @@ export default function AdminSettingsPage() {
               port: Number(smtpPort),
               secure: smtpSecure,
               username: smtpUsername,
-              password: smtpPassword,
+              password: smtpPassword || undefined,
               fromName: smtpFromName,
               fromEmail: smtpFromEmail,
             },
@@ -254,7 +254,7 @@ export default function AdminSettingsPage() {
             provider: "BREVO",
             recipientEmail: normalizedRecipient,
             brevo: {
-              apiKey: brevoApiKey.trim(),
+              apiKey: brevoApiKey.trim() || undefined,
               fromName: brevoFromName,
               fromEmail: brevoFromEmail,
             },

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -176,18 +176,27 @@ export const UpdateSystemSettingSchema = z.object({
 
 export const EmailProviderTypeSchema = z.enum(["SMTP", "BREVO"]);
 
+const OptionalNonEmptyStringSchema = z.preprocess((value) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}, z.string().min(1).optional());
+
 export const SmtpConfigSchema = z.object({
   host: z.string().min(1),
   port: z.number().int().min(1).max(65535),
   secure: z.boolean(),
   username: z.string().min(1),
-  password: z.string().min(1).optional(),
+  password: OptionalNonEmptyStringSchema,
   fromName: z.string().min(1).max(100),
   fromEmail: z.email(),
 });
 
 export const BrevoConfigSchema = z.object({
-  apiKey: z.string().min(1).optional(),
+  apiKey: OptionalNonEmptyStringSchema,
   fromName: z.string().min(1).max(100),
   fromEmail: z.email(),
 });


### PR DESCRIPTION
## Summary
- normalize blank/whitespace SMTP password and Brevo API key to undefined in validation schemas
- send undefined (not empty string) for blank write-only secret fields from admin test payload

## Why
When the write-only Brevo API key input is left blank, the UI sent an empty string and schema validation failed with:
"Too small: expected string to have >=1 characters"
This blocked fallback to the stored encrypted key.

## Validation
- npm run lint
- npx tsc --noEmit