### PR TITLE
Update profile menu label and show uploaded avatar

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 import { AppShell } from "@/components/layout/AppShell";
 import { UserProvider, type UserContextType } from "@/components/providers/UserProvider";
 import { requireUser } from "@/lib/user-session";
+import { hasProfileImageByUserId } from "@/repositories/profile-image.repo";
 import { getTeamsByUserId } from "@/repositories/team.repo";
 
 export default async function DashboardLayout({
@@ -9,12 +10,16 @@ export default async function DashboardLayout({
   children: React.ReactNode;
 }) {
   const sessionUser = await requireUser();
-  const teams = await getTeamsByUserId(sessionUser.userId);
+  const [teams, hasProfileImage] = await Promise.all([
+    getTeamsByUserId(sessionUser.userId),
+    hasProfileImageByUserId(sessionUser.userId),
+  ]);
 
   const userData: UserContextType = {
     userId: sessionUser.userId,
     name: sessionUser.name,
     email: sessionUser.email,
+    hasProfileImage,
     isSystemAdmin: sessionUser.isSystemAdmin,
     mustChangePassword: sessionUser.mustChangePassword,
     isVerified: sessionUser.isVerified,

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -341,6 +341,7 @@ export default function SettingsPage() {
       setAvatarVersion((v) => v + 1);
       setAvatarHasError(false);
       setSuccess("Profile image updated");
+      router.refresh();
     } catch {
       setError("An unexpected error occurred");
     } finally {
@@ -364,6 +365,7 @@ export default function SettingsPage() {
       setAvatarVersion((v) => v + 1);
       setAvatarHasError(false);
       setSuccess("Profile image removed");
+      router.refresh();
     } catch {
       setError("An unexpected error occurred");
     } finally {
@@ -373,7 +375,7 @@ export default function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 animate-enter">
-      <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)]">Settings</h1>
+      <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)]">Profile</h1>
 
       {error && (
         <div className="alert-danger rounded-xl p-3 text-sm">

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -3,10 +3,11 @@
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { useUser } from "@/components/providers/UserProvider";
 
 export function UserMenu() {
-  const { name, email, isSystemAdmin } = useUser();
+  const { name, email, hasProfileImage, isSystemAdmin } = useUser();
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -40,8 +41,21 @@ export function UserMenu() {
         onClick={() => setOpen(!open)}
         className="focus-ring flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm transition-colors hover:bg-[var(--surface-2)]"
       >
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color-mix(in_oklab,var(--primary)_16%,transparent)] text-xs font-bold text-[var(--primary)]">
-          {initials}
+        <div className="relative flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-[color-mix(in_oklab,var(--primary)_16%,transparent)] text-xs font-bold text-[var(--primary)]">
+          <span>{initials}</span>
+          {hasProfileImage && (
+            <Image
+              src="/api/user/profile-image"
+              alt={`${name} profile`}
+              width={32}
+              height={32}
+              unoptimized
+              className="absolute inset-0 h-8 w-8 rounded-full object-cover"
+              onError={(e) => {
+                e.currentTarget.style.display = "none";
+              }}
+            />
+          )}
         </div>
         <div className="min-w-0 flex-1 text-left">
           <div className="truncate font-medium text-[var(--text)]">{name}</div>
@@ -52,7 +66,7 @@ export function UserMenu() {
       {open && (
         <div className="absolute bottom-full left-3 right-3 z-50 mb-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-1 shadow-[var(--shadow-md)]">
           <Link href="/settings" onClick={() => setOpen(false)} className="block rounded-lg px-3 py-2 text-sm text-[var(--text)] hover:bg-[var(--surface-2)]">
-            Settings
+            Profile
           </Link>
           <Link href="/teams/new" onClick={() => setOpen(false)} className="block rounded-lg px-3 py-2 text-sm text-[var(--text)] hover:bg-[var(--surface-2)]">
             Create Team

--- a/src/components/providers/UserProvider.tsx
+++ b/src/components/providers/UserProvider.tsx
@@ -16,6 +16,7 @@ export interface UserContextType {
   userId: string;
   name: string;
   email: string;
+  hasProfileImage: boolean;
   isSystemAdmin: boolean;
   mustChangePassword: boolean;
   isVerified: boolean;

--- a/src/repositories/profile-image.repo.ts
+++ b/src/repositories/profile-image.repo.ts
@@ -7,6 +7,15 @@ export async function getProfileImageByUserId(userId: string) {
   });
 }
 
+export async function hasProfileImageByUserId(userId: string) {
+  const prisma = await getPrisma();
+  const image = await prisma.userProfileImage.findUnique({
+    where: { userId },
+    select: { userId: true },
+  });
+  return Boolean(image);
+}
+
 export async function upsertProfileImage(data: {
   userId: string;
   mimeType: string;


### PR DESCRIPTION
## Summary\n- rename user menu link from Settings to Profile\n- rename dashboard settings page title to Profile\n- show uploaded profile image in sidebar user avatar with initials fallback\n- refresh user context after profile image upload/remove so avatar updates immediately\n\n## Validation\n- npx tsc --noEmit\n- npm run lint