### PR TITLE
Install dependencies in deploy job

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -143,6 +143,9 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Download Vercel prebuilt output
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- restore `npm ci` in the deploy job before `vercel deploy --prebuilt`
- fix post-merge deployment failures caused by missing `node_modules/next/package.json`

## Testing
- workflow logic reviewed locally
- full deploy path requires GitHub Actions, Vercel, and Turso secrets to execute