### PR TITLE
Handle auth callback failures with explicit error responses

### DIFF
--- a/src/app/api/auth/callback/oidc/[slug]/route.ts
+++ b/src/app/api/auth/callback/oidc/[slug]/route.ts
@@ -10,73 +10,96 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ slug: string }> },
 ) {
-  const { slug: expectedSlug } = await params;
-  const url = new URL(request.url);
-  const state = url.searchParams.get("state");
-  const error = url.searchParams.get("error");
+  try {
+    const { slug: expectedSlug } = await params;
+    const url = new URL(request.url);
+    const state = url.searchParams.get("state");
+    const error = url.searchParams.get("error");
 
-  if (error) {
-    const errorDescription =
-      url.searchParams.get("error_description") || "Unknown error";
+    if (error) {
+      const errorDescription =
+        url.searchParams.get("error_description") || "Unknown error";
+      return NextResponse.json(
+        { error, description: errorDescription },
+        { status: 400 },
+      );
+    }
+
+    if (!state) {
+      return NextResponse.json(
+        { error: "Missing state parameter" },
+        { status: 400 },
+      );
+    }
+
+    // Look up state to find slug and code verifier
+    const stateEntry = await getState(state);
+    if (!stateEntry) {
+      return NextResponse.json(
+        { error: "Invalid or expired state parameter" },
+        { status: 400 },
+      );
+    }
+
+    const { slug, codeVerifier } = stateEntry;
+    if (slug !== expectedSlug) {
+      return NextResponse.json(
+        { error: "Callback slug does not match login session" },
+        { status: 400 },
+      );
+    }
+    if (!codeVerifier) {
+      return NextResponse.json(
+        { error: "Missing code verifier for OIDC flow" },
+        { status: 400 },
+      );
+    }
+
+    // Load app instance
+    const appInstance = await getAppInstanceBySlug(slug);
+    if (!appInstance) {
+      return NextResponse.json(
+        { error: "App instance not found" },
+        { status: 404 },
+      );
+    }
+
+    // Process the callback
+    const handler = new OIDCHandler(appInstance);
+    const result = await handler.handleCallback(url, codeVerifier, state);
+
+    // Store in session
+    const session = await getAppSession(slug);
+    session.appSlug = slug;
+    session.protocol = "OIDC";
+    session.claims = result.claims;
+    session.rawToken = result.rawToken;
+    session.idToken = result.idToken;
+    session.accessToken = result.accessToken;
+    session.authenticatedAt = new Date().toISOString();
+    await session.save();
+
+    return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unexpected callback error";
+    const normalized = message.toLowerCase();
+    const isValidationError =
+      normalized.includes("invalid") ||
+      normalized.includes("issuer") ||
+      normalized.includes("audience") ||
+      normalized.includes("nonce") ||
+      normalized.includes("state") ||
+      normalized.includes("code");
+
+    console.error("OIDC callback failed", error);
     return NextResponse.json(
-      { error, description: errorDescription },
-      { status: 400 },
+      {
+        error: isValidationError
+          ? `OIDC validation failed: ${message}`
+          : "OIDC callback failed",
+      },
+      { status: isValidationError ? 400 : 500 },
     );
   }
-
-  if (!state) {
-    return NextResponse.json(
-      { error: "Missing state parameter" },
-      { status: 400 },
-    );
-  }
-
-  // Look up state to find slug and code verifier
-  const stateEntry = await getState(state);
-  if (!stateEntry) {
-    return NextResponse.json(
-      { error: "Invalid or expired state parameter" },
-      { status: 400 },
-    );
-  }
-
-  const { slug, codeVerifier } = stateEntry;
-  if (slug !== expectedSlug) {
-    return NextResponse.json(
-      { error: "Callback slug does not match login session" },
-      { status: 400 },
-    );
-  }
-  if (!codeVerifier) {
-    return NextResponse.json(
-      { error: "Missing code verifier for OIDC flow" },
-      { status: 400 },
-    );
-  }
-
-  // Load app instance
-  const appInstance = await getAppInstanceBySlug(slug);
-  if (!appInstance) {
-    return NextResponse.json(
-      { error: "App instance not found" },
-      { status: 404 },
-    );
-  }
-
-  // Process the callback
-  const handler = new OIDCHandler(appInstance);
-  const result = await handler.handleCallback(url, codeVerifier, state);
-
-  // Store in session
-  const session = await getAppSession(slug);
-  session.appSlug = slug;
-  session.protocol = "OIDC";
-  session.claims = result.claims;
-  session.rawToken = result.rawToken;
-  session.idToken = result.idToken;
-  session.accessToken = result.accessToken;
-  session.authenticatedAt = new Date().toISOString();
-  await session.save();
-
-  return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`);
 }

--- a/src/app/api/auth/callback/oidc/route.ts
+++ b/src/app/api/auth/callback/oidc/route.ts
@@ -7,66 +7,89 @@ import { getAppSession } from "@/lib/session";
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
 export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const state = url.searchParams.get("state");
-  const error = url.searchParams.get("error");
+  try {
+    const url = new URL(request.url);
+    const state = url.searchParams.get("state");
+    const error = url.searchParams.get("error");
 
-  if (error) {
-    const errorDescription =
-      url.searchParams.get("error_description") || "Unknown error";
+    if (error) {
+      const errorDescription =
+        url.searchParams.get("error_description") || "Unknown error";
+      return NextResponse.json(
+        { error, description: errorDescription },
+        { status: 400 },
+      );
+    }
+
+    if (!state) {
+      return NextResponse.json(
+        { error: "Missing state parameter" },
+        { status: 400 },
+      );
+    }
+
+    // Look up state to find slug and code verifier
+    const stateEntry = await getState(state);
+    if (!stateEntry) {
+      return NextResponse.json(
+        { error: "Invalid or expired state parameter" },
+        { status: 400 },
+      );
+    }
+
+    const { slug, codeVerifier } = stateEntry;
+    if (!codeVerifier) {
+      return NextResponse.json(
+        { error: "Missing code verifier for OIDC flow" },
+        { status: 400 },
+      );
+    }
+
+    // Load app instance
+    const appInstance = await getAppInstanceBySlug(slug);
+    if (!appInstance) {
+      return NextResponse.json(
+        { error: "App instance not found" },
+        { status: 404 },
+      );
+    }
+
+    // Process the callback
+    const handler = new OIDCHandler(appInstance);
+    const result = await handler.handleCallback(url, codeVerifier, state);
+
+    // Store in session
+    const session = await getAppSession(slug);
+    session.appSlug = slug;
+    session.protocol = "OIDC";
+    session.claims = result.claims;
+    session.rawToken = result.rawToken;
+    session.idToken = result.idToken;
+    session.accessToken = result.accessToken;
+    session.authenticatedAt = new Date().toISOString();
+    await session.save();
+
+    return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unexpected callback error";
+    const normalized = message.toLowerCase();
+    const isValidationError =
+      normalized.includes("invalid") ||
+      normalized.includes("issuer") ||
+      normalized.includes("audience") ||
+      normalized.includes("nonce") ||
+      normalized.includes("state") ||
+      normalized.includes("code");
+
+    console.error("OIDC callback failed", error);
     return NextResponse.json(
-      { error, description: errorDescription },
-      { status: 400 },
+      {
+        error: isValidationError
+          ? `OIDC validation failed: ${message}`
+          : "OIDC callback failed",
+      },
+      { status: isValidationError ? 400 : 500 },
     );
   }
-
-  if (!state) {
-    return NextResponse.json(
-      { error: "Missing state parameter" },
-      { status: 400 },
-    );
-  }
-
-  // Look up state to find slug and code verifier
-  const stateEntry = await getState(state);
-  if (!stateEntry) {
-    return NextResponse.json(
-      { error: "Invalid or expired state parameter" },
-      { status: 400 },
-    );
-  }
-
-  const { slug, codeVerifier } = stateEntry;
-  if (!codeVerifier) {
-    return NextResponse.json(
-      { error: "Missing code verifier for OIDC flow" },
-      { status: 400 },
-    );
-  }
-
-  // Load app instance
-  const appInstance = await getAppInstanceBySlug(slug);
-  if (!appInstance) {
-    return NextResponse.json(
-      { error: "App instance not found" },
-      { status: 404 },
-    );
-  }
-
-  // Process the callback
-  const handler = new OIDCHandler(appInstance);
-  const result = await handler.handleCallback(url, codeVerifier, state);
-
-  // Store in session
-  const session = await getAppSession(slug);
-  session.appSlug = slug;
-  session.protocol = "OIDC";
-  session.claims = result.claims;
-  session.rawToken = result.rawToken;
-  session.idToken = result.idToken;
-  session.accessToken = result.accessToken;
-  session.authenticatedAt = new Date().toISOString();
-  await session.save();
-
-  return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`);
 }

--- a/src/app/api/auth/callback/saml/[slug]/route.ts
+++ b/src/app/api/auth/callback/saml/[slug]/route.ts
@@ -10,71 +10,96 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ slug: string }> },
 ) {
-  const { slug: expectedSlug } = await params;
-  const formData = await request.formData();
-  const samlResponse = formData.get("SAMLResponse") as string;
-  const relayState = formData.get("RelayState") as string;
+  try {
+    const { slug: expectedSlug } = await params;
+    const formData = await request.formData();
+    const samlResponse = formData.get("SAMLResponse") as string;
+    const relayState = formData.get("RelayState") as string;
 
-  if (!samlResponse) {
-    return NextResponse.json(
-      { error: "Missing SAMLResponse" },
-      { status: 400 },
-    );
-  }
+    if (!samlResponse) {
+      return NextResponse.json(
+        { error: "Missing SAMLResponse" },
+        { status: 400 },
+      );
+    }
 
-  if (!relayState) {
+    if (!relayState) {
+      return NextResponse.json(
+        {
+          error:
+            "Missing RelayState. Start SAML from /test/{slug}/login and ensure your IdP preserves RelayState in the response.",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Look up RelayState to find slug
+    const stateEntry = await getState(relayState);
+    if (!stateEntry) {
+      return NextResponse.json(
+        {
+          error:
+            "Invalid or expired RelayState. This is often caused by an expired flow, missing state cookie, or IdP not returning RelayState.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const { slug } = stateEntry;
+    if (slug !== expectedSlug) {
+      return NextResponse.json(
+        { error: "Callback slug does not match login session" },
+        { status: 400 },
+      );
+    }
+
+    // Load app instance
+    const appInstance = await getAppInstanceBySlug(slug);
+    if (!appInstance) {
+      return NextResponse.json(
+        { error: "App instance not found" },
+        { status: 404 },
+      );
+    }
+
+    const callbackUrl = `${APP_URL}/api/auth/callback/saml/${slug}`;
+
+    // Process the callback
+    const handler = new SAMLHandler(appInstance);
+    const result = await handler.handleCallback(samlResponse, callbackUrl);
+
+    // Store in session
+    const session = await getAppSession(slug);
+    session.appSlug = slug;
+    session.protocol = "SAML";
+    session.claims = result.claims;
+    session.rawXml = result.rawXml;
+    session.authenticatedAt = new Date().toISOString();
+    await session.save();
+
+    return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`, 303);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unexpected callback error";
+    const normalized = message.toLowerCase();
+    const isValidationError =
+      normalized.includes("saml") ||
+      normalized.includes("assertion") ||
+      normalized.includes("relaystate") ||
+      normalized.includes("inresponseto") ||
+      normalized.includes("signature") ||
+      normalized.includes("audience") ||
+      normalized.includes("destination") ||
+      normalized.includes("invalid");
+
+    console.error("SAML callback failed", error);
     return NextResponse.json(
       {
-        error:
-          "Missing RelayState. Start SAML from /test/{slug}/login and ensure your IdP preserves RelayState in the response.",
+        error: isValidationError
+          ? `SAML validation failed: ${message}`
+          : "SAML callback failed",
       },
-      { status: 400 },
+      { status: isValidationError ? 400 : 500 },
     );
   }
-
-  // Look up RelayState to find slug
-  const stateEntry = await getState(relayState);
-  if (!stateEntry) {
-    return NextResponse.json(
-      {
-        error:
-          "Invalid or expired RelayState. This is often caused by an expired flow, missing state cookie, or IdP not returning RelayState.",
-      },
-      { status: 400 },
-    );
-  }
-
-  const { slug } = stateEntry;
-  if (slug !== expectedSlug) {
-    return NextResponse.json(
-      { error: "Callback slug does not match login session" },
-      { status: 400 },
-    );
-  }
-
-  // Load app instance
-  const appInstance = await getAppInstanceBySlug(slug);
-  if (!appInstance) {
-    return NextResponse.json(
-      { error: "App instance not found" },
-      { status: 404 },
-    );
-  }
-
-  const callbackUrl = `${APP_URL}/api/auth/callback/saml/${slug}`;
-
-  // Process the callback
-  const handler = new SAMLHandler(appInstance);
-  const result = await handler.handleCallback(samlResponse, callbackUrl);
-
-  // Store in session
-  const session = await getAppSession(slug);
-  session.appSlug = slug;
-  session.protocol = "SAML";
-  session.claims = result.claims;
-  session.rawXml = result.rawXml;
-  session.authenticatedAt = new Date().toISOString();
-  await session.save();
-
-  return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`, 303);
 }

--- a/src/app/api/auth/callback/saml/route.ts
+++ b/src/app/api/auth/callback/saml/route.ts
@@ -7,64 +7,89 @@ import { getAppSession } from "@/lib/session";
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
 export async function POST(request: Request) {
-  const formData = await request.formData();
-  const samlResponse = formData.get("SAMLResponse") as string;
-  const relayState = formData.get("RelayState") as string;
+  try {
+    const formData = await request.formData();
+    const samlResponse = formData.get("SAMLResponse") as string;
+    const relayState = formData.get("RelayState") as string;
 
-  if (!samlResponse) {
-    return NextResponse.json(
-      { error: "Missing SAMLResponse" },
-      { status: 400 },
-    );
-  }
+    if (!samlResponse) {
+      return NextResponse.json(
+        { error: "Missing SAMLResponse" },
+        { status: 400 },
+      );
+    }
 
-  if (!relayState) {
+    if (!relayState) {
+      return NextResponse.json(
+        {
+          error:
+            "Missing RelayState. Start SAML from /test/{slug}/login and ensure your IdP preserves RelayState in the response.",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Look up RelayState to find slug
+    const stateEntry = await getState(relayState);
+    if (!stateEntry) {
+      return NextResponse.json(
+        {
+          error:
+            "Invalid or expired RelayState. This is often caused by an expired flow, missing state cookie, or IdP not returning RelayState.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const { slug } = stateEntry;
+
+    // Load app instance
+    const appInstance = await getAppInstanceBySlug(slug);
+    if (!appInstance) {
+      return NextResponse.json(
+        { error: "App instance not found" },
+        { status: 404 },
+      );
+    }
+
+    const callbackUrl = `${APP_URL}/api/auth/callback/saml`;
+
+    // Process the callback
+    const handler = new SAMLHandler(appInstance);
+    const result = await handler.handleCallback(samlResponse, callbackUrl);
+
+    // Store in session
+    const session = await getAppSession(slug);
+    session.appSlug = slug;
+    session.protocol = "SAML";
+    session.claims = result.claims;
+    session.rawXml = result.rawXml;
+    session.authenticatedAt = new Date().toISOString();
+    await session.save();
+
+    return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`, 303);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unexpected callback error";
+    const normalized = message.toLowerCase();
+    const isValidationError =
+      normalized.includes("saml") ||
+      normalized.includes("assertion") ||
+      normalized.includes("relaystate") ||
+      normalized.includes("inresponseto") ||
+      normalized.includes("signature") ||
+      normalized.includes("audience") ||
+      normalized.includes("destination") ||
+      normalized.includes("invalid");
+
+    console.error("SAML callback failed", error);
     return NextResponse.json(
       {
-        error:
-          "Missing RelayState. Start SAML from /test/{slug}/login and ensure your IdP preserves RelayState in the response.",
+        error: isValidationError
+          ? `SAML validation failed: ${message}`
+          : "SAML callback failed",
       },
-      { status: 400 },
+      { status: isValidationError ? 400 : 500 },
     );
   }
-
-  // Look up RelayState to find slug
-  const stateEntry = await getState(relayState);
-  if (!stateEntry) {
-    return NextResponse.json(
-      {
-        error:
-          "Invalid or expired RelayState. This is often caused by an expired flow, missing state cookie, or IdP not returning RelayState.",
-      },
-      { status: 400 },
-    );
-  }
-
-  const { slug } = stateEntry;
-
-  // Load app instance
-  const appInstance = await getAppInstanceBySlug(slug);
-  if (!appInstance) {
-    return NextResponse.json(
-      { error: "App instance not found" },
-      { status: 404 },
-    );
-  }
-
-  const callbackUrl = `${APP_URL}/api/auth/callback/saml`;
-
-  // Process the callback
-  const handler = new SAMLHandler(appInstance);
-  const result = await handler.handleCallback(samlResponse, callbackUrl);
-
-  // Store in session
-  const session = await getAppSession(slug);
-  session.appSlug = slug;
-  session.protocol = "SAML";
-  session.claims = result.claims;
-  session.rawXml = result.rawXml;
-  session.authenticatedAt = new Date().toISOString();
-  await session.save();
-
-  return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`, 303);
 }


### PR DESCRIPTION
## Summary
- wrap SAML callback handlers in try/catch and return structured JSON errors
- wrap OIDC callback handlers in try/catch and return structured JSON errors
- classify common validation failures as 400 instead of surfacing generic 500 pages

## Why
Production callback failures were returning generic HTTP 500 responses, which obscured the underlying auth mismatch and made troubleshooting difficult.

## Validation
- npm run lint
- npm run typecheck
- npm run test:unit