### PR TITLE
feat(test): include important URLs on test page

### DIFF
--- a/src/app/test/[slug]/page.tsx
+++ b/src/app/test/[slug]/page.tsx
@@ -18,14 +18,17 @@ export default async function TestPage({
     notFound();
   }
 
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-  const callbackType = app.protocol === "OIDC" ? "oidc" : "saml";
-  const callbackUrl = `${appUrl}/api/auth/callback/${callbackType}/${app.slug}`;
+  const appUrl = (process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000").replace(/\/+$/, "");
+  const testUrl = `${appUrl}/test/${app.slug}`;
+  const testLoginUrl = `${testUrl}/login`;
+  const testInspectorUrl = `${testUrl}/inspector`;
+  const oidcCallbackUrl = `${appUrl}/api/auth/callback/oidc/${app.slug}`;
+  const samlCallbackUrl = `${appUrl}/api/auth/callback/saml/${app.slug}`;
   const unsignedMetadataUrl =
-    app.protocol === "SAML" ? `${appUrl}/api/saml/metadata/${slug}` : null;
+    app.protocol === "SAML" ? `${appUrl}/api/saml/metadata/${app.slug}` : null;
   const signedMetadataUrl =
     app.protocol === "SAML"
-      ? `${appUrl}/api/saml/metadata/${slug}?signed=true`
+      ? `${appUrl}/api/saml/metadata/${app.slug}?signed=true`
       : null;
 
   return (
@@ -53,41 +56,90 @@ export default async function TestPage({
         </Link>
 
         <div className="mt-6 border-t border-[var(--border)] pt-4 text-left">
-          <p className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">Callback URL</p>
-          <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
-            {callbackUrl}
-          </code>
-          <p className="mt-3 text-xs text-[var(--muted)]">
-            Register this URL as the redirect URI in your IdP configuration.
+          <h2 className="text-sm font-semibold text-[var(--text)]">Important URLs</h2>
+          <p className="mt-1 text-xs text-[var(--muted)]">
+            Use the same values shown during app creation when configuring your identity provider.
           </p>
+          <dl className="mt-3 space-y-3">
+            <div>
+              <dt className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">Test URL</dt>
+              <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
+                {testUrl}
+              </code>
+              <div className="mt-1 flex items-center gap-3">
+                <CopyButton text={testUrl} />
+              </div>
+            </div>
+            <div>
+              <dt className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">Test Login URL</dt>
+              <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
+                {testLoginUrl}
+              </code>
+              <div className="mt-1 flex items-center gap-3">
+                <CopyButton text={testLoginUrl} />
+              </div>
+            </div>
+            {app.protocol === "OIDC" ? (
+              <div>
+                <dt className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">OIDC Redirect URI</dt>
+                <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
+                  {oidcCallbackUrl}
+                </code>
+                <div className="mt-1 flex items-center gap-3">
+                  <CopyButton text={oidcCallbackUrl} />
+                </div>
+              </div>
+            ) : (
+              <>
+                <div>
+                  <dt className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">SAML ACS URL (Callback)</dt>
+                  <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
+                    {samlCallbackUrl}
+                  </code>
+                  <div className="mt-1 flex items-center gap-3">
+                    <CopyButton text={samlCallbackUrl} />
+                  </div>
+                </div>
+                {unsignedMetadataUrl && (
+                  <div>
+                    <dt className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">SAML SP Metadata URL</dt>
+                    <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
+                      {unsignedMetadataUrl}
+                    </code>
+                    <div className="mt-1 flex items-center gap-3">
+                      <CopyButton text={unsignedMetadataUrl} />
+                      <a href={unsignedMetadataUrl} className="text-xs text-[var(--primary)] hover:underline">
+                        Download
+                      </a>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+            <div>
+              <dt className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">Inspector URL (after successful login)</dt>
+              <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
+                {testInspectorUrl}
+              </code>
+              <div className="mt-1 flex items-center gap-3">
+                <CopyButton text={testInspectorUrl} />
+              </div>
+            </div>
+          </dl>
 
-          {app.protocol === "SAML" && unsignedMetadataUrl && signedMetadataUrl && (
-            <div className="mt-4 space-y-3">
-              <div>
-                <p className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">SP Metadata URL (Unsigned)</p>
-                <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
-                  {unsignedMetadataUrl}
-                </code>
-                <div className="mt-1 flex items-center gap-3">
-                  <CopyButton text={unsignedMetadataUrl} />
-                  <a href={unsignedMetadataUrl} className="text-xs text-[var(--primary)] hover:underline">
-                    Download
-                  </a>
-                </div>
+          {app.protocol === "SAML" && signedMetadataUrl && (
+            <div className="mt-4 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-3">
+              <p className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">Optional signed metadata URL</p>
+              <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface)] px-2 py-1.5 text-xs text-[var(--text)]">
+                {signedMetadataUrl}
+              </code>
+              <div className="mt-1 flex items-center gap-3">
+                <CopyButton text={signedMetadataUrl} />
+                <a href={signedMetadataUrl} className="text-xs text-[var(--primary)] hover:underline">
+                  Download
+                </a>
               </div>
-              <div>
-                <p className="mb-1 text-xs uppercase tracking-[0.08em] text-[var(--muted)]">SP Metadata URL (Signed)</p>
-                <code className="block break-all rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text)]">
-                  {signedMetadataUrl}
-                </code>
-                <div className="mt-1 flex items-center gap-3">
-                  <CopyButton text={signedMetadataUrl} />
-                  <a href={signedMetadataUrl} className="text-xs text-[var(--primary)] hover:underline">
-                    Download
-                  </a>
-                </div>
-              </div>
-              <p className="text-xs text-[var(--muted)]">
+              <p className="mt-2 text-xs text-[var(--muted)]">
                 Signed metadata requires both <code>SAML_SP_PRIVATE_KEY</code> and <code>SAML_SP_PUBLIC_CERT</code> environment variables.
               </p>
             </div>


### PR DESCRIPTION
## Summary
- mirror the app-creation 'Important URLs' block on /test/{slug}
- include Test URL, Test Login URL, protocol-specific callback/metadata URLs, and Inspector URL
- keep optional signed SAML metadata URL with download/copy actions

## Verification
- npm run test:unit
- npm run lint
- npx tsc --noEmit