### PR TITLE
Add cookie-size fallbacks for auth callback sessions

### DIFF
--- a/src/app/api/auth/callback/oidc/[slug]/route.ts
+++ b/src/app/api/auth/callback/oidc/[slug]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getAppInstanceBySlug } from "@/repositories/app-instance.repo";
 import { OIDCHandler } from "@/lib/oidc-handler";
 import { getState } from "@/lib/state-store";
-import { getAppSession } from "@/lib/session";
+import { getAppSession, saveAuthResultSession } from "@/lib/session";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
@@ -70,14 +70,14 @@ export async function GET(
 
     // Store in session
     const session = await getAppSession(slug);
-    session.appSlug = slug;
-    session.protocol = "OIDC";
-    session.claims = result.claims;
-    session.rawToken = result.rawToken;
-    session.idToken = result.idToken;
-    session.accessToken = result.accessToken;
-    session.authenticatedAt = new Date().toISOString();
-    await session.save();
+    await saveAuthResultSession(session, {
+      slug,
+      protocol: "OIDC",
+      claims: result.claims,
+      rawToken: result.rawToken,
+      idToken: result.idToken,
+      accessToken: result.accessToken,
+    });
 
     return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`);
   } catch (error) {

--- a/src/app/api/auth/callback/oidc/route.ts
+++ b/src/app/api/auth/callback/oidc/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getAppInstanceBySlug } from "@/repositories/app-instance.repo";
 import { OIDCHandler } from "@/lib/oidc-handler";
 import { getState } from "@/lib/state-store";
-import { getAppSession } from "@/lib/session";
+import { getAppSession, saveAuthResultSession } from "@/lib/session";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
@@ -60,14 +60,14 @@ export async function GET(request: Request) {
 
     // Store in session
     const session = await getAppSession(slug);
-    session.appSlug = slug;
-    session.protocol = "OIDC";
-    session.claims = result.claims;
-    session.rawToken = result.rawToken;
-    session.idToken = result.idToken;
-    session.accessToken = result.accessToken;
-    session.authenticatedAt = new Date().toISOString();
-    await session.save();
+    await saveAuthResultSession(session, {
+      slug,
+      protocol: "OIDC",
+      claims: result.claims,
+      rawToken: result.rawToken,
+      idToken: result.idToken,
+      accessToken: result.accessToken,
+    });
 
     return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`);
   } catch (error) {

--- a/src/app/api/auth/callback/saml/[slug]/route.ts
+++ b/src/app/api/auth/callback/saml/[slug]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getAppInstanceBySlug } from "@/repositories/app-instance.repo";
 import { SAMLHandler } from "@/lib/saml-handler";
 import { getState } from "@/lib/state-store";
-import { getAppSession } from "@/lib/session";
+import { getAppSession, saveAuthResultSession } from "@/lib/session";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
@@ -70,12 +70,12 @@ export async function POST(
 
     // Store in session
     const session = await getAppSession(slug);
-    session.appSlug = slug;
-    session.protocol = "SAML";
-    session.claims = result.claims;
-    session.rawXml = result.rawXml;
-    session.authenticatedAt = new Date().toISOString();
-    await session.save();
+    await saveAuthResultSession(session, {
+      slug,
+      protocol: "SAML",
+      claims: result.claims,
+      rawXml: result.rawXml,
+    });
 
     return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`, 303);
   } catch (error) {

--- a/src/app/api/auth/callback/saml/route.ts
+++ b/src/app/api/auth/callback/saml/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getAppInstanceBySlug } from "@/repositories/app-instance.repo";
 import { SAMLHandler } from "@/lib/saml-handler";
 import { getState } from "@/lib/state-store";
-import { getAppSession } from "@/lib/session";
+import { getAppSession, saveAuthResultSession } from "@/lib/session";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
@@ -60,12 +60,12 @@ export async function POST(request: Request) {
 
     // Store in session
     const session = await getAppSession(slug);
-    session.appSlug = slug;
-    session.protocol = "SAML";
-    session.claims = result.claims;
-    session.rawXml = result.rawXml;
-    session.authenticatedAt = new Date().toISOString();
-    await session.save();
+    await saveAuthResultSession(session, {
+      slug,
+      protocol: "SAML",
+      claims: result.claims,
+      rawXml: result.rawXml,
+    });
 
     return NextResponse.redirect(`${APP_URL}/test/${slug}/inspector`, 303);
   } catch (error) {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -20,3 +20,74 @@ export async function getAppSession(slug: string) {
     cookieName: `authlab_${slug}`,
   });
 }
+
+type SessionProtocol = "OIDC" | "SAML";
+
+interface SaveAuthSessionInput {
+  slug: string;
+  protocol: SessionProtocol;
+  claims: Record<string, unknown>;
+  rawToken?: string;
+  rawXml?: string;
+  idToken?: string;
+  accessToken?: string;
+}
+
+function isCookieTooBigError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("Cookie length is too big")
+  );
+}
+
+function buildCompactClaims(claims: Record<string, unknown>): Record<string, unknown> {
+  const keys = Object.keys(claims);
+  return {
+    _truncated: true,
+    _reason: "Session payload exceeded cookie size limit",
+    _claimCount: keys.length,
+    _claimKeys: keys.slice(0, 100),
+  };
+}
+
+export async function saveAuthResultSession(
+  session: SessionData & { save: () => Promise<void> },
+  input: SaveAuthSessionInput,
+): Promise<void> {
+  session.appSlug = input.slug;
+  session.protocol = input.protocol;
+  session.claims = input.claims;
+  session.rawToken = input.rawToken;
+  session.rawXml = input.rawXml;
+  session.idToken = input.idToken;
+  session.accessToken = input.accessToken;
+  session.authenticatedAt = new Date().toISOString();
+
+  try {
+    await session.save();
+    return;
+  } catch (error) {
+    if (!isCookieTooBigError(error)) {
+      throw error;
+    }
+  }
+
+  // First fallback: remove largest raw payload fields.
+  session.rawXml = undefined;
+  session.rawToken = undefined;
+  session.accessToken = undefined;
+
+  try {
+    await session.save();
+    return;
+  } catch (error) {
+    if (!isCookieTooBigError(error)) {
+      throw error;
+    }
+  }
+
+  // Final fallback: keep only compact claim metadata.
+  session.claims = buildCompactClaims(input.claims);
+  session.idToken = undefined;
+  await session.save();
+}


### PR DESCRIPTION
## Summary
- add a session-save helper with cookie-size fallback strategy for iron-session
- retry session save by removing large raw payload fields when cookie exceeds browser limits
- fall back to compact claim metadata if payload is still too large
- update SAML and OIDC callback routes to use the helper

## Why
SAML/OIDC callbacks can include large payloads (especially SAML raw XML). Storing full payloads in cookie-backed sessions can exceed the 4096-byte browser cookie limit and cause callback failures.

## Validation
- npm run typecheck
- npm run test:unit