### PR TITLE
fix: notes validation for client-side save

### DIFF
--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -93,8 +93,8 @@ const AppCredentialSchema = z.object({
 const AppNotesSchema = z.object({
   markdown: z.string().max(5000).default(""),
   credentials: z.array(AppCredentialSchema).max(10).default([]),
-  updatedAt: z.string(),
-  updatedBy: z.string(),
+  updatedAt: z.string().optional().default(""),
+  updatedBy: z.string().optional().default(""),
 });
 
 export const UpdateAppInstanceSchema = z.object({


### PR DESCRIPTION
## Summary
- Fix notes save failing with "Validation failed" — `updatedAt`/`updatedBy` were required in Zod schema but are injected server-side, not sent by the client

## Commits
- `6486676` fix: make notes updatedAt/updatedBy optional in validation

## Test plan
- [x] `npm run test:unit` — 144/144 pass
- [x] Manual: notes save works after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)