### PR TITLE
Merge beta to main: notes caching fix

### DIFF
--- a/src/app/api/apps/[id]/notes/route.ts
+++ b/src/app/api/apps/[id]/notes/route.ts
@@ -24,5 +24,7 @@ export async function GET(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  return NextResponse.json({ notes: result.notes });
+  return NextResponse.json({ notes: result.notes }, {
+    headers: { "Cache-Control": "no-store" },
+  });
 }

--- a/src/components/apps/AppNotesEditor.tsx
+++ b/src/components/apps/AppNotesEditor.tsx
@@ -51,7 +51,7 @@ export function AppNotesEditor({ appId, initial, onSaved, onCancel }: AppNotesEd
         throw new Error(data?.error || `Save failed (${res.status})`);
       }
       // Re-fetch decrypted notes (PUT returns redacted instance without notes content)
-      const notesRes = await fetch(`/api/apps/${appId}/notes`);
+      const notesRes = await fetch(`/api/apps/${appId}/notes`, { cache: "no-store" });
       if (notesRes.ok) {
         const notesData = await notesRes.json();
         onSaved(notesData.notes ?? body.notes);

--- a/src/components/apps/Dashboard.tsx
+++ b/src/components/apps/Dashboard.tsx
@@ -206,7 +206,7 @@ export function Dashboard({ initialApps, team, currentUserId }: DashboardProps) 
     setNotesLoading(true);
     setNotesData(null);
     try {
-      const res = await fetch(`/api/apps/${app.id}/notes`);
+      const res = await fetch(`/api/apps/${app.id}/notes`, { cache: "no-store" });
       if (res.ok) {
         const data = await res.json();
         setNotesData(data.notes ?? null);


### PR DESCRIPTION
## Summary
- **fix:** Prevent browser caching of `GET /api/apps/[id]/notes` so saved credentials persist in UI after save
- Added `Cache-Control: no-store` header on the API response
- Added `cache: "no-store"` to client-side fetch calls in Dashboard and AppNotesEditor

## Test plan
- [x] Unit tests pass (144/144)
- [x] Integration and security tests unchanged (pre-existing failures unrelated)
- [x] Manual: save credentials → verify they remain visible after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)