### PR TITLE
fix: notes credential save and validation improvements

### DIFF
--- a/src/components/apps/AppNotesEditor.tsx
+++ b/src/components/apps/AppNotesEditor.tsx
@@ -35,10 +35,18 @@ export function AppNotesEditor({ appId, initial, onSaved, onCancel }: AppNotesEd
     setSaving(true);
     setError(null);
     try {
+      // Separate fully-empty rows (discard) from partially-filled rows (validate)
+      const nonEmpty = credentials.filter(
+        (c) => c.label.trim() || c.username.trim() || c.password.trim(),
+      );
+      const incomplete = nonEmpty.filter((c) => !c.label.trim() || !c.username.trim());
+      if (incomplete.length > 0) {
+        throw new Error("Each credential needs at least a label and username.");
+      }
       const body = {
         notes: {
           markdown,
-          credentials: credentials.filter((c) => c.label.trim() && c.username.trim()),
+          credentials: nonEmpty,
         },
       };
       const res = await fetch(`/api/apps/${appId}`, {


### PR DESCRIPTION
## Summary
- Fix silent credential loss: incomplete credentials now show a validation error instead of being silently filtered out during save
- Fix notes fetch caching: add `cache: "no-store"` to client fetches and `Cache-Control: no-store` to the notes API response so saved credentials persist in the UI
- Require both label and username for credential save; relax URL field validation from `.url()` to `.max(500)`
- Make notes `updatedAt`/`updatedBy` optional in validation schema
- Upgrade CI checkout and setup-node actions to v5 (Node.js 24)

## Test plan
- [ ] Add a credential with label + username + password — verify it saves and displays
- [ ] Add a credential with only a label (no username) — verify a validation error appears
- [ ] Add a credential with only a username (no label) — verify a validation error appears
- [ ] Save notes with markdown only (no credentials) — verify markdown persists
- [ ] Close and reopen the notes panel — verify credentials persist across re-fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)